### PR TITLE
fix: address 28 bugs causing queue/playback failures

### DIFF
--- a/FINDINGS.md
+++ b/FINDINGS.md
@@ -1,0 +1,587 @@
+# Auxcord.org Bug Report
+
+Static audit completed on March 30, 2026.
+
+Scope reviewed:
+
+- `server.rb`
+- `spotify.rb`
+- `sonos.rb`
+- `db.rb`
+- all ERB templates under `views/`
+- all JS/CSS partials under `views/js/` and `views/css/`
+
+Notes:
+
+- This report is from source review plus a few local sanity checks (`ruby -c` on the Ruby files).
+- I did not run the full app end-to-end in this environment because the required Ruby/Bundler setup is not available here.
+- External API behavior below is only cited where it materially affects a bug:
+  - Sonos subscription/callback docs: https://docs.sonos.com/docs/subscribe
+  - Sonos auth/token docs: https://docs.sonos.com/docs/authorize
+  - RSpotify token refresh docs: https://github.com/guilhermesad/rspotify
+
+## Critical Findings
+
+### 1. Queue state only exists in process memory
+
+Files:
+
+- `server.rb:9-11`
+- `server.rb:54-70`
+- `server.rb:389-407`
+- `server.rb:530`
+- `server.rb:661-665`
+- `spotify.rb:11-21`
+- `spotify.rb:87-118`
+- `sonos.rb:14-18`
+- `sonos.rb:43-45`
+
+What is wrong:
+
+- Guest queue state is held in Ruby memory only:
+  - `Spotify#queued_songs`
+  - `Spotify#past_songs`
+  - `Sonos#currently_playing_guest_wished_song`
+  - `Sonos#current_item_id`
+  - cached playback metadata
+- The database only persists auth tokens and a few Sonos settings.
+
+Why it causes the reported symptoms:
+
+- Any process restart, deploy, crash, or horizontal scaling event wipes the queue and playback state.
+- After a restart, the app forgets which guest song is playing and what should play next, so queued songs can disappear, duplicates can be allowed again, and callback-driven queue advancement can stop.
+- In a multi-process deployment, one request can queue a song into process A while the Sonos callback lands on process B, which has an empty queue. That will look exactly like “the song queued successfully, but never played.”
+
+### 2. Queueing is race-prone and not synchronized
+
+Files:
+
+- `server.rb:364-412`
+- `server.rb:480-580`
+- `spotify.rb:87-118`
+
+What is wrong:
+
+- Queue mutations happen from multiple request threads plus callback handling with no mutex or transactional protection.
+- The code performs multi-step read/check/write sequences on shared arrays and flags:
+  - duplicate check
+  - `queued_songs << song`
+  - `queued_songs.shift`
+  - `past_songs << next_song`
+  - `currently_playing_guest_wished_song = ...`
+- The first guest song also spawns a detached `Thread.new` to enqueue on Sonos.
+
+Why it causes the reported symptoms:
+
+- Two guests submitting at nearly the same time can both pass the duplicate check, both see `currently_playing_guest_wished_song == false`, and both start Sonos queue work.
+- `Spotify#add_next_song_to_sonos_queue!` clears the playlist and shifts from the queue before the Sonos insert succeeds, so concurrent calls can reorder songs, drop songs, or queue the wrong song next.
+- This is a direct explanation for intermittent “sometimes it works, sometimes it doesn’t” queue failures.
+
+### 3. The app reports success before Sonos queueing actually succeeds
+
+Files:
+
+- `server.rb:404-411`
+- `spotify.rb:92-118`
+
+What is wrong:
+
+- On the first guest request, the server immediately returns `success: true` and `position: 0`.
+- The actual Sonos insert happens later on a background thread.
+- There is no join, no error capture, and no retry.
+
+Why it causes the reported symptoms:
+
+- Users can get a success popup even when:
+  - the Sonos favorite lookup fails
+  - the Sonos insert fails
+  - the Spotify playlist update fails
+  - the auth token is stale
+- The UI says “it will be played next” even though nothing was actually inserted into the Sonos queue.
+
+### 4. Failed Sonos inserts permanently lose songs and can wedge the queue
+
+Files:
+
+- `server.rb:404-407`
+- `spotify.rb:94-118`
+
+What is wrong:
+
+- `Spotify#add_next_song_to_sonos_queue!` does this in order:
+  1. clears the playlist
+  2. `shift`s the next song out of memory
+  3. appends it to `past_songs`
+  4. adds it to the Spotify playlist
+  5. looks up the Sonos favorite
+  6. sends the Sonos `INSERT_NEXT`
+  7. removes the track from the playlist again
+- If any step after `shift` fails, the song is already gone from the real queue and marked as “past.”
+- In the route, `currently_playing_guest_wished_song` is set to `true` before the background queue operation succeeds.
+
+Why it causes the reported symptoms:
+
+- A failed first insert can leave the system thinking a guest song is active even though none was queued on Sonos.
+- Later guest requests then go into the in-memory array and wait for a callback that never arrives.
+- From the user’s point of view: the first song “queued” but never plays, and future songs pile up forever.
+
+### 5. Sonos callback handling violates Sonos’s timing guidance
+
+Files:
+
+- `server.rb:480-580`
+
+What is wrong:
+
+- Sonos documents that callback handlers should return `200` quickly, ideally within 1 second, and defer lengthy work.
+- This handler does the opposite before responding:
+  - parses and logs the full JSON body
+  - may call `play_music!`
+  - may call `add_next_song_to_sonos_queue!`
+  - may hit Spotify twice via `find_song`
+  - may update playback caches
+- Only after all of that does it send `status 200`.
+
+Why it causes the reported symptoms:
+
+- Slow Spotify/Sonos API calls can push the callback over Sonos’s timeout window.
+- Sonos may retry or drop events.
+- Since queue advancement depends on these callbacks, dropped playback events translate directly into “next queued song never started.”
+
+### 6. Sonos subscriptions are never renewed and are not recreated for new groups
+
+Files:
+
+- `sonos.rb:46-55`
+- `server.rb:312-322`
+- `server.rb:486-487`
+
+What is wrong:
+
+- The app subscribes to playback and playback metadata only once during `Sonos#initialize`.
+- Sonos documents that subscriptions live for a maximum of three days and that clients must resubscribe when groups move or change.
+- When the host changes `group_to_use`, the code updates the group ID and restarts playback, but never subscribes the new group.
+
+Why it causes the reported symptoms:
+
+- After a speaker-group change, callbacks for the new group never arrive.
+- The callback router only matches events whose `X-Sonos-Target-Value` equals the current `group_to_use`, so old-group callbacks are ignored once the group changes.
+- After a few days, even unchanged groups can silently stop delivering events if the subscription expires.
+- Result: queue advancement stops, playback state gets stale, and songs stop chaining correctly.
+
+## High Findings
+
+### 7. Background maintenance threads die permanently on the first exception
+
+Files:
+
+- `server.rb:57-70`
+- `sonos.rb:87-99`
+
+What is wrong:
+
+- The two long-lived background loops have no per-user rescue.
+- Any exception from one Sonos account kills the entire thread.
+
+Why it causes the reported symptoms:
+
+- One transient Sonos API failure can permanently stop:
+  - automatic volume enforcement
+  - playback enforcement
+  - cache refreshes for groups/favorites
+- After that, the host dashboard uses stale group/favorite data and playback drift is no longer corrected.
+
+### 8. Logging out deletes DB rows but leaves live in-memory sessions active
+
+Files:
+
+- `server.rb:327-338`
+- `server.rb:651-658`
+
+What is wrong:
+
+- `/logout` deletes database rows and clears `session[:user_id]`, but it does not remove the user’s objects from `GlobalState[:spotify_instances]` and `GlobalState[:sonos_instances]`.
+
+Why it causes the reported symptoms:
+
+- Existing invite links can keep working until the process restarts because the guest endpoints resolve from the in-memory hashes, not the DB.
+- The deleted Sonos instance may also stay in the background loops and callback router.
+- This is both a security problem and a source of confusing “I logged out but the old party still sort of works” behavior.
+
+### 9. Invalid or stale guest links crash instead of failing safely
+
+Files:
+
+- `server.rb:345-360`
+- `server.rb:364-389`
+- `server.rb:619-631`
+
+What is wrong:
+
+- Guest routes assume `spotify_instances[user_id]` and `sonos_instances[user_id]` exist.
+- There is no nil guard before calling `party_playlist`, `queued_songs_json`, or `search_for_song`.
+
+Why it causes the reported symptoms:
+
+- Any stale QR code, deleted party, restarted process, or guessed URL can produce `NoMethodError` and a 500.
+- To a guest this shows up as “general breakage” or “the queue page is broken.”
+
+### 10. Bad/removed Spotify track IDs crash the queue endpoint
+
+Files:
+
+- `server.rb:379-382`
+- `spotify.rb:71-84`
+
+What is wrong:
+
+- `spotify_instance.find_song` explicitly rescues and returns `nil`.
+- The route immediately calls `song_to_queue.id.to_s` during duplicate checking with no nil guard.
+
+Why it causes the reported symptoms:
+
+- If Spotify search returns a track that later becomes unavailable, or the client submits a bad ID, the queue request 500s.
+- Guests see a generic failure instead of a recoverable error message.
+
+### 11. Sonos OAuth state is hardcoded and never validated
+
+Files:
+
+- `server.rb:87-94`
+- `server.rb:418-476`
+
+What is wrong:
+
+- The Sonos auth URL always uses `state=TESTSTATE`.
+- The callback does not verify `state` at all.
+
+Why it causes the reported symptoms:
+
+- This is a standard OAuth CSRF/account-mixup bug.
+- A malicious or stale auth redirect can attach the wrong Sonos household to the current browser session.
+- In practice that can manifest as “my host dashboard controls the wrong speakers” or “my session suddenly broke after reauth.”
+
+### 12. Sonos callbacks are accepted without signature verification
+
+Files:
+
+- `server.rb:480-580`
+
+What is wrong:
+
+- Sonos sends `X-Sonos-Event-Signature` and recommends verifying it.
+- The app trusts any POST body sent to `/callback`.
+
+Why it causes the reported symptoms:
+
+- Anyone who can hit that endpoint can spoof playback events and trigger queue advancement, forced resume, or state corruption.
+- Even accidental/bogus traffic can mutate `current_item_id` and the guest-song flag.
+
+### 13. CSRF protection is missing on host-control endpoints
+
+Files:
+
+- `server.rb:285-325`
+- `server.rb:327-339`
+
+What is wrong:
+
+- The host control route accepts state-changing POSTs with only the session cookie.
+- `/logout` is a destructive GET.
+- There are no CSRF tokens and no origin/referrer checks.
+
+Why it causes the reported symptoms:
+
+- A logged-in host can be tricked into:
+  - pausing/resuming playback
+  - changing volume
+  - skipping songs
+  - changing groups
+  - deleting all stored auth tokens via `/logout`
+- This is an obvious security issue.
+
+### 14. Spotify token refresh is not persisted
+
+Files:
+
+- `spotify.rb:23-27`
+- `spotify.rb:129-162`
+
+External reference:
+
+- RSpotify documents automatic refresh, but also explicitly recommends persisting refreshed credentials via `access_refresh_callback` or `to_hash`.
+
+What is wrong:
+
+- `spotify_user` rebuilds a fresh `RSpotify::User` object from the DB row on every call.
+- The stored JSON is only written once during initial auth.
+- No `access_refresh_callback` is configured, and refreshed credentials are never written back to `Db.spotify_tokens`.
+
+Why it causes the reported symptoms:
+
+- Once the original Spotify access token ages out, the app repeatedly reconstructs users from stale credentials.
+- Best case: every request has to refresh again, adding latency and fragility.
+- Worst case: if Spotify changes refresh-token behavior or the stale token data is no longer accepted, playlist/search calls start failing and queueing breaks.
+
+### 15. Duplicate Spotify auth rows are possible and the code reads an arbitrary one
+
+Files:
+
+- `db.rb:37-46`
+- `spotify.rb:29-33`
+- `spotify.rb:159-162`
+- `server.rb:590-600`
+
+What is wrong:
+
+- `spotify_tokens.user_id` is not unique.
+- Each Spotify auth callback inserts a new row.
+- Reads use `.where(user_id: user_id).first`, which is not deterministic across duplicates.
+
+Why it causes the reported symptoms:
+
+- Reconnecting Spotify can leave old token rows behind.
+- The app may later pick a stale row with an old playlist ID or expired credentials.
+- That produces intermittent auth failures that are hard to reproduce.
+
+### 16. `primary_household` rescue path returns the wrong type
+
+Files:
+
+- `sonos.rb:169-188`
+
+What is wrong:
+
+- The normal path returns a household ID string.
+- The rescue path stores `households.first`, which is a household hash, not its ID.
+
+Why it causes the reported symptoms:
+
+- After any exception during household enumeration, later API paths interpolate a hash into URLs like `/households/#{primary_household}/favorites`.
+- That can break all Sonos API requests for that user until restart/re-auth.
+
+## Medium Findings
+
+### 17. Host group changes made outside auxcord can break the current selection
+
+Files:
+
+- `sonos.rb:36-41`
+- `server.rb:174-181`
+- `server.rb:224-232`
+
+What is wrong:
+
+- The code repairs an invalid group only during `Sonos#initialize`.
+- If the selected Sonos group disappears later due to regrouping in the Sonos app, the live session keeps the stale `group_to_use`.
+
+Why it causes the reported symptoms:
+
+- Playback/control requests start targeting a dead group ID.
+- `party_data` can also blow up when it does `find { ... }['name']` and `find` returns `nil`.
+- This produces broken dashboards and failed playback control after speaker regrouping.
+
+### 18. Search autocomplete does too much work and lacks failure guards
+
+Files:
+
+- `server.rb:630-648`
+
+What is wrong:
+
+- For every search request, the endpoint fetches `audio_features` for every returned track.
+- There is no rescue if `audio_features` is nil or if one of those requests fails/rate-limits.
+
+Why it causes the reported symptoms:
+
+- Autocomplete gets slow because one text search fans out into many extra Spotify calls.
+- One bad track can fail the whole response and break the search UI.
+- Under load, this increases the chance of Spotify errors that the frontend reports only as “something went wrong.”
+
+### 19. Search text is not URL-encoded on the guest page
+
+Files:
+
+- `views/js/_queue_song.js.erb:5-7`
+
+What is wrong:
+
+- The code concatenates raw input directly into `?song_name=` instead of using `encodeURIComponent`.
+
+Why it causes the reported symptoms:
+
+- Searches containing `&`, `#`, `%`, `+`, or `?` can be truncated or malformed.
+- Guests can get empty or wrong results even though the song exists.
+
+### 20. Host dashboard polling uses synchronous XHR
+
+Files:
+
+- `views/js/_party.js.erb:147-159`
+
+What is wrong:
+
+- `xhr.open("GET", "/party.json", false)` is a synchronous request.
+
+Why it causes the reported symptoms:
+
+- Every 2.5 seconds the browser can block the main thread while waiting for the server.
+- When the server is slow, the whole host UI freezes or becomes visibly janky.
+- This makes the dashboard feel broken exactly when the backend is already under stress.
+
+### 21. Clicking the groups button throws because the target element is commented out
+
+Files:
+
+- `views/party.erb:53-57`
+- `views/js/_party.js.erb:116-126`
+
+What is wrong:
+
+- The JS expects an element with `id="groups-div"`.
+- The template has that element commented out.
+
+Why it causes the reported symptoms:
+
+- Clicking the groups button dereferences `null.style`.
+- One host interaction can break the rest of the page’s JS execution.
+
+### 22. Pause/play icon refresh logic can hide both icons
+
+Files:
+
+- `views/js/_party.js.erb:18`
+- `views/js/_party.js.erb:74-79`
+
+What is wrong:
+
+- `refreshUI` only hides one icon based on `party_on`; it never explicitly shows the other one.
+- After a few state transitions, both icons can end up hidden.
+
+Why it causes the reported symptoms:
+
+- The host sees a blank or misleading play/pause button even though the underlying route is still being called.
+
+### 23. Login page JS crashes when `#meme-carousel` is absent
+
+Files:
+
+- `views/login.erb:83-154`
+- `views/js/_login.js.erb:2-8`
+
+What is wrong:
+
+- `_login.js.erb` always assumes `document.getElementById('meme-carousel')` exists.
+- The template only renders that element in one branch of the page.
+
+Why it causes the reported symptoms:
+
+- On the “connect Spotify” step, or any other state where the carousel is omitted, the script throws before doing anything else.
+- It is a visible frontend bug and a sign the page was never exercised in that state.
+
+### 24. Initial host page rendering re-runs `party_data` and duplicates API work
+
+Files:
+
+- `server.rb:143-150`
+- `views/js/_party.js.erb:137`
+
+What is wrong:
+
+- The route already computes `pd = party_data`.
+- The JS partial then calls `party_data` again during template rendering.
+
+Why it causes the reported symptoms:
+
+- Each page load doubles the Sonos/Spotify work for the same state snapshot.
+- That increases load, latency, and the chance of timing-sensitive failures on an already fragile path.
+
+## Security Findings
+
+### 25. The app renders third-party metadata without escaping
+
+Files:
+
+- `views/queue_song.erb:11-13`
+- `views/queue_song.erb:37`
+- `views/add_playlist_to_favs.erb:13`
+- `views/js/_party.js.erb:5`
+- `views/js/_party.js.erb:15`
+- `views/js/_party.js.erb:19`
+- `views/js/_party.js.erb:36`
+- `views/js/_queue_song.js.erb:13-17`
+
+What is wrong:
+
+- Server-rendered ERB output is inserted with raw `<%= ... %>`.
+- Client-side code uses `innerHTML` and string-built HTML for Spotify/Sonos data.
+- Track names, artist names, playlist names, and group names are treated as trusted HTML.
+
+Why it causes the reported symptoms:
+
+- This is an XSS risk. A maliciously crafted third-party metadata value can inject markup/script into host or guest pages.
+- Even if exploitation is rare, it is a real trust-boundary problem and should be treated as one.
+
+### 26. Invite links can outlive logout because access is keyed to memory, not the DB
+
+Files:
+
+- `server.rb:345-360`
+- `server.rb:364-412`
+- `server.rb:327-338`
+
+What is wrong:
+
+- Guest routes resolve parties from the in-memory instance hashes, not from current DB records.
+- Logout only deletes DB rows.
+
+Why it causes the reported symptoms:
+
+- A host can believe a party is gone while old guest URLs remain usable until restart.
+- That is both a security leak and another explanation for “weirdly stale” behavior after logout.
+
+## Minor Frontend / Miscellaneous Bugs
+
+### 27. Several asset whitelist entries do not match real files
+
+Files:
+
+- `server.rb:111-129`
+- `views/assets/`
+
+What is wrong:
+
+- The whitelist includes paths like `/assets/favicon-16x16.ico`, `/assets/favicon-32x32.ico`, `/assets/android-chrome-512x512`, and `/assets/android-chrome-192x192`.
+- The actual files are `.png`.
+
+Why it causes the reported symptoms:
+
+- Some icons will 404 if requested.
+- This is minor, but it confirms the asset path handling is brittle.
+
+### 28. The queue page has malformed HTML
+
+Files:
+
+- `views/queue_song.erb:37`
+
+What is wrong:
+
+- The “Felix Krause” link is missing its closing `</a>`.
+
+Why it causes the reported symptoms:
+
+- Browsers usually recover, but malformed DOM can cause layout/debugging oddities and is another sign the page was not validated carefully.
+
+## Most Likely Root Causes Of “Songs Don’t Play”
+
+The strongest explanations for the reported production symptoms are:
+
+1. In-memory-only queue state being lost across restarts or between processes.
+2. Races around `queued_songs` / `currently_playing_guest_wished_song`.
+3. Returning success before the Sonos insert succeeds.
+4. Failed first inserts wedging the queue because the state says a guest song is active when none was actually queued.
+5. Sonos callback events being delayed/dropped because the handler does too much before returning `200`.
+6. Sonos subscriptions expiring or never being recreated after a group change.
+
+If I had to prioritize fixes, I would start there before touching any cosmetic frontend issues.

--- a/db.rb
+++ b/db.rb
@@ -4,6 +4,15 @@ require 'sequel'
 
 module SonosPartyMode
   class Db
+    def self.ensure_column(table_name, column_name, type, **options)
+      existing_columns = shared_database.schema(table_name).map(&:first)
+      return if existing_columns.include?(column_name)
+
+      shared_database.alter_table(table_name) do
+        add_column column_name, type, **options
+      end
+    end
+
     def self.shared_database
       @shared_database ||= Sequel.connect(ENV.fetch('DATABASE_URL'))
     end
@@ -29,8 +38,12 @@ module SonosPartyMode
           String :group
           String :household
           TrueClass :party_active
+          TrueClass :currently_playing_guest_wished_song, default: false
+          String :current_item_id
         end
       end
+      ensure_column(:sonos_tokens, :currently_playing_guest_wished_song, TrueClass, default: false)
+      ensure_column(:sonos_tokens, :current_item_id, String)
       return shared_database[:sonos_tokens]
     end
 
@@ -41,8 +54,12 @@ module SonosPartyMode
           foreign_key :user_id, :users
           String :options
           String :playlist_id
+          String :queue_track_ids, text: true
+          String :past_track_ids, text: true
         end
       end
+      ensure_column(:spotify_tokens, :queue_track_ids, String, text: true)
+      ensure_column(:spotify_tokens, :past_track_ids, String, text: true)
       return shared_database[:spotify_tokens]
     end
   end

--- a/server.rb
+++ b/server.rb
@@ -2,6 +2,9 @@
 require 'sinatra/base'
 require 'rspotify'
 require 'rqrcode'
+require 'openssl'
+require 'base64'
+require 'securerandom'
 require_relative './sonos'
 require_relative './spotify'
 require_relative './db'
@@ -56,14 +59,28 @@ module SonosPartyMode
       # Ongoing background thread to monitor all Sonos systems
       Thread.new do
         loop do
-          ensure_current_sonos_settings!
+          sonos_instances.each do |user_id, sonos|
+            begin
+              sonos.ensure_current_sonos_settings!
+            rescue => ex
+              puts "Failed to enforce Sonos settings for user #{user_id}"
+              puts ex
+              puts ex.backtrace.join("\n")
+            end
+          end
           sleep(2)
         end
       end
       Thread.new do
         loop do
-          sonos_instances.each do |_user_id, sonos|
-            sonos.refresh_caches
+          sonos_instances.each do |user_id, sonos|
+            begin
+              sonos.refresh_caches
+            rescue => ex
+              puts "Failed to refresh Sonos caches for user #{user_id}"
+              puts ex
+              puts ex.backtrace.join("\n")
+            end
           end
           sleep(15)
         end
@@ -78,6 +95,131 @@ module SonosPartyMode
       return sonos_instances[session[:user_id]] && spotify_instances[session[:user_id]]
     end
 
+    def csrf_token
+      session[:csrf_token] ||= SecureRandom.hex(32)
+    end
+
+    def verify_csrf_token!
+      submitted_token = params[:csrf_token].to_s
+      submitted_token = request.env.fetch('HTTP_X_CSRF_TOKEN', '').to_s if submitted_token.empty?
+      halt 403, 'Invalid CSRF token' if submitted_token.empty?
+      halt 403, 'Invalid CSRF token' unless submitted_token.bytesize == csrf_token.bytesize &&
+                                            Rack::Utils.secure_compare(submitted_token, csrf_token)
+    end
+
+    def verify_sonos_callback_signature!(raw_body)
+      signing_key = ENV.fetch('SONOS_SECRET', '').to_s
+      return if signing_key.empty?
+
+      provided_signature = request.env.fetch('HTTP_X_SONOS_EVENT_SIGNATURE', '').to_s
+      halt 401, 'Missing Sonos event signature' if provided_signature.empty?
+
+      expected_signature = Base64.strict_encode64(
+        OpenSSL::HMAC.digest('sha256', signing_key, raw_body)
+      )
+      halt 401, 'Invalid Sonos event signature' unless provided_signature.bytesize == expected_signature.bytesize &&
+                                                      Rack::Utils.secure_compare(provided_signature, expected_signature)
+    end
+
+    def remove_user_from_memory!(user_id)
+      sonos_instances.delete(user_id)
+      spotify_instances.delete(user_id)
+    end
+
+    def queue_snapshot_tracks(spotify_instance, sonos_instance)
+      queued_songs = spotify_instance.queued_songs.dup
+      queued_songs.unshift(spotify_instance.past_songs.last) if spotify_instance.past_songs.count.positive? &&
+                                                                 sonos_instance.currently_playing_guest_wished_song
+      queued_songs.compact
+    end
+
+    def track_to_json(track)
+      album_images = track.album.images || []
+      album_image = album_images.last || album_images.first
+      {
+        album_cover: album_image && album_image['url'],
+        name: track.name,
+        artists: track.artists.map(&:name).join(', '),
+        id: track.id.to_s,
+        duration: track.duration_ms.to_i / 1000,
+        uri: track.uri
+      }
+    end
+
+    def json_for_script(data)
+      json = data.is_a?(String) ? data : data.to_json
+      json.gsub('<', '\u003c').gsub('>', '\u003e').gsub('&', '\u0026')
+    end
+
+    def process_sonos_callback(raw_body:, sonos_group_id:)
+      info = JSON.parse(raw_body)
+      puts "Received Sonos Web API callback for #{sonos_group_id}"
+
+      filtered_instances = sonos_instances.values.find_all { |instance| instance.group_to_use == sonos_group_id }
+      if filtered_instances.count.zero?
+        puts "Couldn't find the Sonos instance for #{sonos_group_id}"
+        return
+      end
+
+      spotify_instance = nil
+      sonos_instance = nil
+      filtered_instances.each do |instance|
+        spotify_candidate = spotify_instances[instance.user_id]
+        next if spotify_candidate.nil?
+
+        spotify_instance = spotify_candidate
+        sonos_instance = instance
+        break
+      end
+      if spotify_instance.nil?
+        puts "Couldn't find the Spotify instance for #{filtered_instances}"
+        return
+      end
+
+      puts "\n\nSonos Notification\n\n"
+      puts JSON.pretty_generate(info)
+      puts "\n\n"
+
+      if info['playbackState'] && !%w[PLAYBACK_STATE_PLAYING
+                                      PLAYBACK_STATE_BUFFERING].include?(info.fetch('playbackState'))
+        puts 'user paused the group...'
+        sonos_instance.play_music! if sonos_instance.party_session_active
+      end
+
+      if info['itemId']
+        spotify_instance.queue_mutex.synchronize do
+          transitioned_to_new_song = sonos_instance.current_item_id != info.fetch('itemId') &&
+                                     sonos_instance.current_item_id == info.fetch('previousItemId')
+
+          sonos_instance.current_item_id = info.fetch('itemId')
+
+          if transitioned_to_new_song
+            puts 'Queue the new song now'
+            queued_successfully = spotify_instance.add_next_song_to_sonos_queue!(sonos_instance)
+            sonos_instance.currently_playing_guest_wished_song = queued_successfully
+          end
+        end
+      end
+
+      if info['container']
+        sonos_instance.did_receive_new_playback_metadata(info)
+
+        if info['currentItem'] && info['currentItem']['track'] && info['currentItem']['track']['id']
+          current_spotify_object_id = info['currentItem']['track']['id']['objectId']
+          spotify_instance.find_song(current_spotify_object_id)
+        end
+
+        if info['nextItem'] && info['nextItem']['track'] && info['nextItem']['track']['id']
+          next_spotify_object_id = info['nextItem']['track']['id']['objectId']
+          spotify_instance.find_song(next_spotify_object_id)
+        end
+      end
+    rescue => ex
+      puts "Failed to process Sonos callback for #{sonos_group_id}"
+      puts ex
+      puts ex.backtrace.join("\n")
+    end
+
     get '/' do
       @title = 'Login'
 
@@ -85,11 +227,12 @@ module SonosPartyMode
       @number_of_parties = SonosPartyMode::Db.users.count
 
       if session[:user_id].nil? || SonosPartyMode::Db.sonos_tokens.where(user_id: session[:user_id]).count.zero?
+        session[:sonos_state_key] = SecureRandom.hex(32)
         redirect_uri = "#{HOST_URL}/sonos/authorized.html"
         @sonos_login_url = 'https://api.sonos.com/login/v3/oauth?' \
                            "client_id=#{ENV.fetch('SONOS_KEY')}&" \
                            'response_type=code&' \
-                           'state=TESTSTATE&' \
+                           "state=#{session[:sonos_state_key]}&" \
                            'scope=playback-control-all&' \
                            "redirect_uri=#{ERB::Util.url_encode(redirect_uri)}"
         return erb :login
@@ -103,8 +246,14 @@ module SonosPartyMode
     end
 
     def ensure_current_sonos_settings!
-      sonos_instances.each do |_user_id, sonos|
-        sonos.ensure_current_sonos_settings!
+      sonos_instances.each do |user_id, sonos|
+        begin
+          sonos.ensure_current_sonos_settings!
+        rescue => ex
+          puts "Failed to ensure Sonos settings for user #{user_id}"
+          puts ex
+          puts ex.backtrace.join("\n")
+        end
       end
     end
 
@@ -115,11 +264,11 @@ module SonosPartyMode
         '/assets/add-to-sonos-2.png',
         '/assets/add-to-sonos-3.png',
         '/assets/favicon.ico',
-        '/assets/favicon-16x16.ico',
-        '/assets/favicon-32x32.ico',
+        '/assets/favicon-16x16.png',
+        '/assets/favicon-32x32.png',
         '/assets/apple-touch-icon.png',
-        '/assets/android-chrome-512x512',
-        '/assets/android-chrome-192x192',
+        '/assets/android-chrome-512x512.png',
+        '/assets/android-chrome-192x192.png',
         '/assets/logo.png',
         '/assets/spotify-logo.png'
       ].include?(request.path) || request.path.start_with?('/assets/memes/')
@@ -147,7 +296,7 @@ module SonosPartyMode
         @already_submitted = params['submitted'].to_s == 'true'
         return erb :add_playlist_to_favs
       else
-        return erb :party, locals: pd
+        return erb :party, locals: pd.merge(initial_party_data: pd)
       end
     end
 
@@ -167,6 +316,7 @@ module SonosPartyMode
     def party_data
       spotify_instance = spotify_instances[session[:user_id]]
       sonos_instance = sonos_instances[session[:user_id]]
+      return { redirect: '/' } if spotify_instance.nil? || sonos_instance.nil?
 
       spotify_playlist = spotify_instance.party_playlist
       spotify_playlist_id = spotify_playlist.id
@@ -174,16 +324,18 @@ module SonosPartyMode
       playback_metadata = sonos_instance.playback_metadata
       if Hash(Hash(playback_metadata.fetch('currentItem', nil)).fetch('track', nil)).fetch('id', nil).nil?
         sonos_groups = sonos_instance.groups_cached || sonos_instance.groups
+        selected_group = sonos_groups&.find { |group| group['id'] == sonos_instance.group_to_use }
         # Nothing playing
         return {
           nothing_playing: true,
-          group_to_use: sonos_groups.find { |a| a['id'] == sonos_instance.group_to_use }['name']
+          group_to_use: selected_group ? selected_group['name'] : 'Unknown group'
         }
       end
       current_spotify_object_id = playback_metadata['currentItem']['track']['id']['objectId'] rescue nil
       if current_spotify_object_id
         current_spotify_track = spotify_instance.find_song(current_spotify_object_id)
-        current_image_url = current_spotify_track.album.images[1]['url'] if current_spotify_track
+        current_image = current_spotify_track&.album&.images&.[](1) || current_spotify_track&.album&.images&.last
+        current_image_url = current_image && current_image['url']
       else
         current_spotify_track = nil
         current_image_url = nil
@@ -196,7 +348,8 @@ module SonosPartyMode
       next_spotify_object_id = playback_metadata['nextItem']['track']['id']['objectId'] rescue nil
       if next_spotify_object_id
         next_spotify_track = spotify_instance.find_song(next_spotify_object_id)
-        next_image_url = next_spotify_track.album.images[1]['url'] if next_spotify_track
+        next_image = next_spotify_track&.album&.images&.[](1) || next_spotify_track&.album&.images&.last
+        next_image_url = next_image && next_image['url']
       else
         next_spotify_track = nil
         next_image_url = nil
@@ -222,7 +375,7 @@ module SonosPartyMode
       party_on = sonos_instance.party_session_active
 
       sonos_groups = sonos_instance.groups_cached || sonos_instance.groups
-      groups = sonos_groups.collect do |group|
+      groups = Array(sonos_groups).collect do |group|
         {
           name: group.fetch('name'),
           id: group.fetch('id'),
@@ -287,6 +440,7 @@ module SonosPartyMode
         redirect '/'
         return
       end
+      verify_csrf_token!
 
       sonos = sonos_instances[session[:user_id]]
 
@@ -313,9 +467,8 @@ module SonosPartyMode
         # First, pause playback at the current group
         sonos.pause_playback!
 
-        # Update the currently used group in the database, as well as the current session
-        Db.sonos_tokens.where(user_id: session[:user_id]).update(group: params[:group_to_use]) # now, store in db for next run, important to use full query
-        sonos.group_to_use = params[:group_to_use]
+        available_group_ids = Array(sonos.groups_cached || sonos.groups).map { |group| group['id'] }
+        sonos.group_to_use = params[:group_to_use] if available_group_ids.include?(params[:group_to_use])
 
         # Now, trigger playing on the new group
         sonos.ensure_music_playing! if sonos.party_session_active # but only if the party is currently active
@@ -325,14 +478,21 @@ module SonosPartyMode
     end
 
     get '/logout' do
+      redirect '/'
+    end
+
+    post '/logout' do
       unless all_sessions?
         redirect '/'
         return
       end
+      verify_csrf_token!
 
-      Db.sonos_tokens.where(user_id: session[:user_id]).delete
-      Db.spotify_tokens.where(user_id: session[:user_id]).delete
-      Db.users.where(id: session[:user_id]).delete
+      user_id = session[:user_id]
+      Db.sonos_tokens.where(user_id: user_id).delete
+      Db.spotify_tokens.where(user_id: user_id).delete
+      Db.users.where(id: user_id).delete
+      remove_user_from_memory!(user_id)
       session.delete(:user_id)
 
       redirect '/?logged_out=true'
@@ -347,6 +507,12 @@ module SonosPartyMode
 
       # No auth here, we just verify the 2 IDs
       spotify_instance = spotify_instances[params[:user_id].to_i]
+      sonos_instance = sonos_instances[params[:user_id].to_i]
+      if spotify_instance.nil? || sonos_instance.nil?
+        redirect '/'
+        return
+      end
+
       spotify_playlist = spotify_instance.party_playlist
       if spotify_playlist.id != params[:playlist_id]
         redirect '/'
@@ -354,7 +520,6 @@ module SonosPartyMode
       end
 
       # Fetch the current queue, so we can render it
-      sonos_instance = sonos_instances[params[:user_id].to_i]
       @queued_songs = queued_songs_json(spotify_instance, sonos_instance)
 
       erb :queue_song
@@ -366,56 +531,80 @@ module SonosPartyMode
 
       user_id = params[:user_id].to_i
       spotify_instance = spotify_instances[user_id]
-      spotify_playlist = spotify_instance.party_playlist
       sonos_instance = sonos_instances[user_id]
+      if spotify_instance.nil? || sonos_instance.nil?
+        status 404
+        return { success: false, error: 'This party is no longer available' }.to_json
+      end
+
+      spotify_playlist = spotify_instance.party_playlist
 
       # To make sure the user actually has the full link, and the IDs match
       if spotify_playlist.id != params[:playlist_id]
-        redirect '/'
-        return
+        status 403
+        return { success: false, error: 'Unauthorized' }.to_json
       end
 
       # Queue that song
       song_to_queue = spotify_instance.find_song(params.fetch(:song_id))
-      
-      # Verify we haven't already played this song
-      if queued_songs_json(spotify_instance, sonos_instance).any? { |song| song[:id] == song_to_queue.id.to_s }
-        puts "Already played this song"
+      if song_to_queue.nil?
+        status 404
         return {
           success: false,
-          error: 'Song was already played, or is already in the queue'
+          error: 'This Spotify song is no longer available'
         }.to_json
       end
-      spotify_instance.add_song_to_queue(song_to_queue)
 
-      # Check if we can queue right away, or if we have to wait for the next song to start
-      # This basically means, that no user wished song is currently playing, but the default playlist only
-      puts "sonos_instance.currently_playing_guest_wished_song: #{sonos_instance.currently_playing_guest_wished_song}"
-      if sonos_instance.currently_playing_guest_wished_song
-        return {
-          success: true,
-          position: spotify_instance.queued_songs.count
-        }.to_json
-      else
-        if spotify_instance.queued_songs.count != 1
-          puts 'Something went wrong'
-          puts spotify_instance.queued_songs
+      result = spotify_instance.queue_mutex.synchronize do
+        existing_track_ids = (spotify_instance.queued_songs + spotify_instance.past_songs).filter_map { |track| track&.id.to_s }
+        if existing_track_ids.include?(song_to_queue.id.to_s)
+          puts 'Already played this song'
+          {
+            success: false,
+            error: 'Song was already played, or is already in the queue'
+          }
+        else
+          spotify_instance.add_song_to_queue(song_to_queue)
+
+          puts "sonos_instance.currently_playing_guest_wished_song: #{sonos_instance.currently_playing_guest_wished_song}"
+          if sonos_instance.currently_playing_guest_wished_song
+            {
+              success: true,
+              position: spotify_instance.queued_songs.count
+            }
+          else
+            queued_successfully = spotify_instance.add_next_song_to_sonos_queue!(sonos_instance)
+            sonos_instance.currently_playing_guest_wished_song = queued_successfully
+
+            if queued_successfully
+              {
+                success: true,
+                position: 0
+              }
+            else
+              {
+                success: false,
+                error: 'Failed to queue the song on Sonos. Please try again in a moment.'
+              }
+            end
+          end
         end
-        sonos_instance.currently_playing_guest_wished_song = true
-        Thread.new do # async
-          spotify_instance.add_next_song_to_sonos_queue!(sonos_instance)
-        end
-        return {
-          success: true,
-          position: 0
-        }.to_json
       end
+
+      result.to_json
     end
 
     # -----------------------
     # Sonos Specific Code
     # -----------------------
     get '/sonos/authorized.html' do
+      if params[:state].to_s.empty? || params[:state] != session[:sonos_state_key]
+        session[:sonos_state_key] = nil
+        redirect '/?error=invalid_sonos_state'
+        return
+      end
+      session[:sonos_state_key] = nil
+
       # So, this user is serious, they onboarded Sonos, so we now create an entry for them
       # First, create a new user
       user_id = SonosPartyMode::Db.users.insert
@@ -478,104 +667,14 @@ module SonosPartyMode
 
     # Sonos callback information (ping, hook)
     post '/callback' do
-      info = JSON.parse(request.body.read)
-      sonos_group_id = request.env.fetch('HTTP_X_SONOS_TARGET_VALUE')
-      puts "Received Sonos Web API callback for #{sonos_group_id}"
+      raw_body = request.body.read.to_s
+      verify_sonos_callback_signature!(raw_body)
+      sonos_group_id = request.env.fetch('HTTP_X_SONOS_TARGET_VALUE', nil)
 
-      # Find the matching sonos session to use
-      filtered_instances = sonos_instances.values.find_all { |a| a.group_to_use == sonos_group_id }
-      if filtered_instances.count.zero? # not a Sonos system we actively manage (any more)
-        puts "Couldn't find the Sonos instance for #{sonos_group_id}"
-        return
+      Thread.new do
+        process_sonos_callback(raw_body: raw_body, sonos_group_id: sonos_group_id)
       end
 
-      # iterate over multiple, in case there was half an auth, and we have an old session
-      spotify_instance = nil
-      sonos_instance = nil
-      filtered_instances.each do |ins|
-        spotify_instance = spotify_instances[ins.user_id]
-        if spotify_instance
-          sonos_instance = ins
-          break
-        end
-      end
-      if spotify_instance.nil? # not yet fully connected
-        puts "Couldn't find the spotify instance for #{filtered_instances}"
-        return
-      end
-
-      puts "\n\nSonos Notification\n\n"
-      puts JSON.pretty_generate(info)
-      puts "\n\n"
-
-      if info['playbackState'] && !%w[PLAYBACK_STATE_PLAYING
-                                      PLAYBACK_STATE_BUFFERING].include?(info.fetch('playbackState'))
-        puts 'user paused the group...'
-        sonos_instance.play_music! if sonos_instance.party_session_active
-      end
-
-      if info['itemId']
-        if sonos_instance.current_item_id != info.fetch('itemId') &&
-           sonos_instance.current_item_id == info.fetch('previousItemId')
-          puts 'mismatching item IDs, this means the song is over'
-
-          # Set it immediately, as the Sonos web requests do take some time to complete
-          sonos_instance.current_item_id = info.fetch('itemId') # always set it
-
-          # This means, the user has skipped to the next song, or the song has finished playing
-          # we use this to do proper queueing of upcoming songs
-
-          # We queue the next song (after this one's finished)
-          puts 'Queue the new song now'
-          sonos_instance.currently_playing_guest_wished_song = spotify_instance.add_next_song_to_sonos_queue!(sonos_instance)
-          sonos_instance.current_item_id = info.fetch('itemId')
-        end
-
-        sonos_instance.current_item_id = info.fetch('itemId') # always set it
-        # => {"playbackState"=>"PLAYBACK_STATE_PLAYING",
-        #   "isDucking"=>false,
-        #   "itemId"=>"3d6iqwIjxdilDioPqbhU4cJPTGs=",
-        #   "positionMillis"=>14,
-        #   "previousItemId"=>"FwZvKUVmIj3zb3OsjfPQjF8BWsg=",
-        #   "previousPositionMillis"=>60368,
-        #   "playModes"=>{"repeat"=>false, "repeatOne"=>false, "shuffle"=>false, "crossfade"=>false},
-        #   "availablePlaybackActions"=>
-        #    {"canSkip"=>true,
-        #     "canSkipBack"=>true,
-        #     "canSeek"=>true,
-        #     "canPause"=>true,
-        #     "canStop"=>true,
-        #     "canRepeat"=>true,
-        #     "canRepeatOne"=>true,
-        #     "canCrossfade"=>true,
-        #     "canShuffle"=>true}}
-      end
-
-      if info['container']
-        sonos_instance.did_receive_new_playback_metadata(info)
-
-        # Pre-load the song's information from Spotify to get the album cover and other details
-        # which is used by the party host's dashboard, reducing the load time from 5s to 0.5s
-        # Even not assigning the variable, this is a cache
-        if info['currentItem'] && info['currentItem']["track"] && info['currentItem']['track']["id"]
-          current_spotify_object_id = info['currentItem']['track']['id']['objectId']
-          spotify_instance.find_song(current_spotify_object_id)
-        end
-
-        if info['nextItem'] && info['nextItem']['track'] && info['nextItem']['track']["id"]
-          next_spotify_object_id = info['nextItem']['track']['id']['objectId']
-          spotify_instance.find_song(next_spotify_object_id)
-        end
-        # the `info` `track` entries are `nil` when there is no playlist playing atm
-        # this is handled already with `#nothing-playing`
-      end
-
-      # Respond to Sonos
-      #
-      # When you receive an event, send a 200 OK response to let the Sonos cloud know that your client received it. Any response outside of the 200 range will be considered an error, including no response. Sonos also considers a 301 redirect an error as it does not follow redirects for events.
-      # If Sonos isn’t able to send an event to your client, it retries every second for three tries. After the third try, if the Sonos cloud receives another error response or no response, it drops the event. Sonos does not backlog or replay events.
-      # Make sure that your client responds to events quickly (within 1 second). To make sure that apps don’t accidentally run over the timeout limit, we recommend that you defer any lengthy event processing until after you’ve sent the 200 OK response.
-      # As a best practice, you should unsubscribe to namespaces before terminating your event service.
       status 200
       body ''
     end
@@ -621,31 +720,33 @@ module SonosPartyMode
 
       song_name = params.fetch(:song_name)
       user_id = params[:user_id].to_i
-      spotify_playlist = spotify_instances[user_id].party_playlist
+      spotify_instance = spotify_instances[user_id]
+      if spotify_instance.nil?
+        status 404
+        return { error: 'This party is no longer available' }.to_json
+      end
+
+      spotify_playlist = spotify_instance.party_playlist
 
       # To make sure the user actually has the full link, and the IDs match
       return { error: 'Unauthorized' }.to_json if spotify_playlist.id != params[:playlist_id]
-      return {}.to_json if song_name.to_s.strip.empty?
+      return [].to_json if song_name.to_s.strip.empty?
 
       puts "Searching for Spotify song using name #{song_name}"
-      songs = spotify_instances[user_id].search_for_song(song_name)
+      songs = spotify_instance.search_for_song(song_name)
       return songs.collect do |song|
-        audio_features = song.audio_features
         {
           id: song.id,
           name: song.name,
           artists: song.artists.collect(&:name),
-          thumbnail: song.album.images[1]['url'],
-          danceability: audio_features.danceability,
-          energy: audio_features.energy,
-          tempo: audio_features.tempo,
-          loudness: audio_features.loudness,
-          liveness: audio_features.liveness,
-          acousticness: audio_features.acousticness,
-          speechiness: audio_features.speechiness,
-          valence: audio_features.valence,
+          thumbnail: (song.album.images[1] || song.album.images.last || {})['url']
         }
       end.to_json
+    rescue => ex
+      puts "Spotify search failed for user #{user_id}"
+      puts ex
+      puts ex.backtrace.join("\n")
+      [].to_json
     end
 
     # Caching state
@@ -659,20 +760,10 @@ module SonosPartyMode
 
     # Others
     def queued_songs_json(spotify_instance, sonos_instance)
-      queued_songs = spotify_instance.queued_songs.dup # `.dup` to not modify the actual queue
-
-      # Manually prefix the most recently queued song, as it's already in the Sonos queue
-      queued_songs.unshift(spotify_instance.past_songs.last) if spotify_instance.past_songs.count.positive? && sonos_instance.currently_playing_guest_wished_song
-
-      return queued_songs.collect do |track|
-        {
-          album_cover: track.album.images[-1]['url'],
-          name: track.name,
-          artists: track.artists.map(&:name).join(', '),
-          id: track.id.to_s,
-          duration: track.duration_ms.to_i / 1000,
-          uri: track.uri
-        }
+      spotify_instance.queue_mutex.synchronize do
+        return queue_snapshot_tracks(spotify_instance, sonos_instance).collect do |track|
+          track_to_json(track)
+        end
       end
     end
 

--- a/sonos.rb
+++ b/sonos.rb
@@ -6,13 +6,15 @@ require_relative './db'
 
 module SonosPartyMode
   class Sonos
+    SUBSCRIPTION_REFRESH_INTERVAL = 60 * 60 * 24
+
     # Basic attributes
     attr_accessor :user_id
-    attr_accessor :group_to_use, :currently_playing_guest_wished_song, :favorites_cached
+    attr_accessor :favorites_cached
     attr_reader :party_session_active
 
     # Queueing system
-    attr_accessor :current_item_id # it's being set by the `/callback` triggers
+    attr_reader :current_item_id # it's being set by the `/callback` triggers
 
     # Session specific settings
     attr_accessor :target_volume
@@ -30,29 +32,37 @@ module SonosPartyMode
 
       @target_volume = database_row[:volume] # default volume is defined as part of `db.rb`
       @group_to_use = database_row[:group]
-      groups_cached = groups
+      self.groups_cached = groups
       return if groups_cached.nil? # no household
 
-      unless groups_cached.collect { |a| a['id'] }.include?(@group_to_use)
-        # The group ID doesn't exist any more, fallback to the default one (most speakers)
-        @group_to_use = groups_cached.sort_by { |a| a['playerIds'].count }.reverse.first.fetch('id')
-        # Also store the resulting group in the database
-        Db.sonos_tokens.where(user_id: user_id).update(group: @group_to_use) # important to use full query
-      end
+      validate_group_to_use!(force_refresh: false)
 
       @party_session_active = database_row[:party_active] || false
-      @currently_playing_guest_wished_song = false
+      @currently_playing_guest_wished_song = database_row[:currently_playing_guest_wished_song] || false
+      @current_item_id = database_row[:current_item_id]
+      @subscriptions_refreshed_at = Time.at(0)
 
-      subscribe_to_playback
-      subscribe_to_playback_metadata
+      resubscribe!
     end
 
     def subscribe_to_playback
-      client_control_request("/groups/#{group_to_use}/playback/subscription", method: :post)
+      client_control_request("/groups/#{active_group_to_use}/playback/subscription", method: :post)
     end
 
     def subscribe_to_playback_metadata
-      client_control_request("/groups/#{group_to_use}/playbackMetadata/subscription", method: :post)
+      client_control_request("/groups/#{active_group_to_use}/playbackMetadata/subscription", method: :post)
+    end
+
+    def resubscribe!
+      subscribe_to_playback
+      subscribe_to_playback_metadata
+      @subscriptions_refreshed_at = Time.now
+    end
+
+    def ensure_subscriptions!
+      return if @subscriptions_refreshed_at && (Time.now - @subscriptions_refreshed_at) < SUBSCRIPTION_REFRESH_INTERVAL
+
+      resubscribe!
     end
 
     def did_receive_new_playback_metadata(info)
@@ -67,7 +77,7 @@ module SonosPartyMode
       end
 
       # fallback, in case we didn't get a Sonos message yet. I confirmed it's the exact same data
-      return client_control_request("groups/#{group_to_use}/playbackMetadata")
+      return client_control_request("groups/#{active_group_to_use}/playbackMetadata")
     end
 
     def ensure_playlist_in_favorites(spotify_playlist_id, force_refresh: true)
@@ -95,11 +105,13 @@ module SonosPartyMode
     # Called every ~15s
     def refresh_caches
       self.groups_cached = groups
+      validate_group_to_use!(force_refresh: false)
       self.favorites_cached = client_control_request("/households/#{primary_household}/favorites")
+      ensure_subscriptions!
     end
 
     def playback_status
-      status = client_control_request("/groups/#{group_to_use}/playback")
+      status = client_control_request("/groups/#{active_group_to_use}/playback")
       return status.fetch('playbackState')
     end
 
@@ -115,24 +127,24 @@ module SonosPartyMode
 
     def play_music!
       puts 'Resuming playback for Sonos system'
-      client_control_request("groups/#{group_to_use}/playback/play", method: :post)
+      client_control_request("groups/#{active_group_to_use}/playback/play", method: :post)
     end
 
     def pause_playback!
       return unless playback_is_playing?
 
       puts 'Pausing playback for Sonos system'
-      client_control_request("groups/#{group_to_use}/playback/pause", method: :post)
+      client_control_request("groups/#{active_group_to_use}/playback/pause", method: :post)
     end
 
     def skip_song!
       puts 'Skipping song'
-      client_control_request("/groups/#{group_to_use}/playback/skipToNextTrack", method: :post)
+      client_control_request("/groups/#{active_group_to_use}/playback/skipToNextTrack", method: :post)
     end
 
     def get_volume
       # {"volume"=>40, "muted"=>false, "fixed"=>false}
-      client_control_request("groups/#{group_to_use}/groupVolume")
+      client_control_request("groups/#{active_group_to_use}/groupVolume")
     end
 
     def ensure_volume!(goal_volume, check_first: true)
@@ -144,7 +156,7 @@ module SonosPartyMode
 
       # The request below will set the volume
       client_control_request(
-        "groups/#{group_to_use}/groupVolume",
+        "groups/#{active_group_to_use}/groupVolume",
         method: :post,
         body: { volume: goal_volume }
       )
@@ -156,7 +168,7 @@ module SonosPartyMode
       # to check if any of the speakers in a given group is muted, so it's best to just
       # send this API request from time to time in the background
       client_control_request(
-        "groups/#{group_to_use}/groupVolume/mute",
+        "groups/#{active_group_to_use}/groupVolume/mute",
         method: :post,
         body: { muted: false }
       )
@@ -184,7 +196,7 @@ module SonosPartyMode
     rescue => ex
       puts ex
       puts ex.backtrace.join("\n")
-      @_primary_household ||= households.first
+      @_primary_household ||= households.first['id']
     end
 
     def households
@@ -194,6 +206,30 @@ module SonosPartyMode
     def groups
       return nil if primary_household.nil?
       client_control_request("/households/#{primary_household}/groups").fetch('groups', nil)
+    end
+
+    def group_to_use
+      active_group_to_use(force_refresh: false)
+    end
+
+    def group_to_use=(value)
+      assign_group_to_use!(value, persist: true, resubscribe: true)
+    end
+
+    def currently_playing_guest_wished_song=(value)
+      @currently_playing_guest_wished_song = !!value
+      Db.sonos_tokens.where(user_id: user_id).update(
+        currently_playing_guest_wished_song: @currently_playing_guest_wished_song
+      )
+    end
+
+    def currently_playing_guest_wished_song
+      @currently_playing_guest_wished_song
+    end
+
+    def current_item_id=(value)
+      @current_item_id = value
+      Db.sonos_tokens.where(user_id: user_id).update(current_item_id: value)
     end
 
     def access_token
@@ -297,6 +333,33 @@ module SonosPartyMode
         expires_in: response.fetch('expires_in')
       )
       Db.sonos_tokens.where(user_id: user_id).update(household: primary_household)
+    end
+
+    def active_group_to_use(force_refresh: true)
+      validate_group_to_use!(force_refresh: force_refresh)
+      @group_to_use
+    end
+
+    def validate_group_to_use!(force_refresh: true)
+      available_groups = if force_refresh || groups_cached.nil?
+                           self.groups_cached = groups
+                         else
+                           groups_cached
+                         end
+      return nil if available_groups.nil? || available_groups.empty?
+
+      return @group_to_use if available_groups.any? { |group| group['id'] == @group_to_use }
+
+      fallback_group = available_groups.max_by { |group| group.fetch('playerIds', []).count }
+      assign_group_to_use!(fallback_group.fetch('id'), persist: true, resubscribe: true)
+      @group_to_use
+    end
+
+    def assign_group_to_use!(value, persist:, resubscribe:)
+      @group_to_use = value
+      Db.sonos_tokens.where(user_id: user_id).update(group: value) if persist
+      resubscribe! if resubscribe && !value.nil?
+      @group_to_use
     end
   end
 end

--- a/spotify.rb
+++ b/spotify.rb
@@ -3,34 +3,42 @@
 require 'excon'
 require 'rspotify'
 require 'json'
+require 'thread'
 # require "pry"
 require_relative './db'
 
 module SonosPartyMode
   class Spotify
-    attr_accessor :user_id, :queued_songs, :past_songs
+    attr_accessor :user_id
+    attr_reader :queued_songs, :past_songs, :queue_mutex
 
     def initialize(user_id:, authorization_code: nil, redirect_uri: nil)
       self.user_id = user_id
+      @queue_mutex = Mutex.new
       new_auth!(authorization_code: authorization_code, redirect_uri: redirect_uri) if authorization_code
 
       return if database_row.nil? # this is the case if a user didn't finish onboarding
 
-      self.queued_songs = []
-      self.past_songs = []
+      @queued_songs = []
+      @past_songs = []
+      load_queue_state!
     end
 
     def spotify_user
       return nil if database_row.nil?
+      return @_spotify_user if @_spotify_user
 
-      RSpotify::User.new(JSON.parse(database_row.fetch(:options)))
+      options = JSON.parse(database_row.fetch(:options))
+      options['credentials'] ||= {}
+      options['credentials']['access_refresh_callback'] = access_refresh_callback
+      @_spotify_user = RSpotify::User.new(options)
     end
 
     def database_row
       query = Db.spotify_tokens.where(user_id: user_id)
       return nil if query.empty?
 
-      return query.first
+      return query.order(Sequel.desc(:id)).first
     end
 
     def party_playlist
@@ -84,38 +92,56 @@ module SonosPartyMode
     end
 
     # This method will add songs to the queue (playlist) on Spotify, but not yet add it to the Sonos queue
-    def add_song_to_queue(song)      
+    def add_song_to_queue(song)
       queued_songs << song
+      persist_queue_state!
     end
 
     # Actually send all songs wished for to the Sonos queue
-    def add_next_song_to_sonos_queue!(sonos)
-      # First, clear the Spotify playlist, in case there was anything left there
-      party_playlist.remove_tracks!(party_playlist.tracks)
-
-      next_song = queued_songs.shift
+    def add_next_song_to_sonos_queue!(sonos, retries: 3, retry_delay: 1)
+      next_song = queued_songs.first
       if next_song.nil?
         puts 'No more auxcord songs in queue...'
         return false
       end
-      past_songs << next_song
-      party_playlist.add_tracks!([next_song])
 
-      # Get the Sonos ID of the favorite playlist
-      fav_id = sonos.ensure_playlist_in_favorites(party_playlist.id)
+      attempt = 0
+      begin
+        attempt += 1
 
-      # Queue the one song from that playlist into the Sonos Queue
-      puts "Queueing #{next_song.name} by #{next_song.artists.first.name} to Sonos"
-      sonos.client_control_request(
-        "/groups/#{sonos.group_to_use}/favorites",
-        method: :post,
-        body: {
-          favoriteId: fav_id.fetch('id'),
-          action: 'INSERT_NEXT'
-        }
-      )
-      party_playlist.remove_tracks!([next_song])
-      return true
+        # First, clear the Spotify playlist, in case there was anything left there
+        clear_party_playlist!
+        party_playlist.add_tracks!([next_song])
+
+        # Get the Sonos ID of the favorite playlist
+        fav_id = sonos.ensure_playlist_in_favorites(party_playlist.id)
+        raise 'Missing Sonos favorite for Spotify playlist' if fav_id.nil?
+
+        # Queue the one song from that playlist into the Sonos Queue
+        puts "Queueing #{next_song.name} by #{next_song.artists.first.name} to Sonos"
+        sonos.client_control_request(
+          "/groups/#{sonos.group_to_use}/favorites",
+          method: :post,
+          body: {
+            favoriteId: fav_id.fetch('id'),
+            action: 'INSERT_NEXT'
+          }
+        )
+
+        queued_songs.shift
+        past_songs << next_song
+        persist_queue_state!
+        true
+      rescue => ex
+        puts "Failed to queue next Sonos song for user #{user_id} (attempt #{attempt}/#{retries})"
+        puts ex
+        puts ex.backtrace.join("\n")
+        retry if attempt < retries && sleep(retry_delay * attempt)
+
+        false
+      ensure
+        cleanup_playlist_song!(next_song)
+      end
     end
 
     def self.permission_scope
@@ -156,10 +182,93 @@ module SonosPartyMode
         'info' => info_parsed
       }
       RSpotify::User.new(options)
-      Db.spotify_tokens.insert(
+      save_authorized_user!(options)
+      @_spotify_user = nil
+    end
+
+    def access_refresh_callback
+      @access_refresh_callback ||= proc do |new_access_token, token_lifetime|
+        refreshed_options = JSON.parse(database_row.fetch(:options))
+        refreshed_options['credentials'] ||= {}
+        refreshed_options['credentials']['token'] = new_access_token
+        refreshed_options['credentials']['access_token'] = new_access_token
+        refreshed_options['credentials']['expires_in'] = token_lifetime
+        refreshed_options['credentials']['expires_at'] = Time.now.to_i + token_lifetime.to_i
+        persist_spotify_options!(refreshed_options)
+      end
+    end
+
+    def save_authorized_user!(options)
+      query = Db.spotify_tokens.where(user_id: user_id)
+      latest_row = query.order(Sequel.desc(:id)).first
+      payload = {
         user_id: user_id,
-        options: JSON.pretty_generate(options.to_hash)
+        options: JSON.pretty_generate(options.to_hash),
+        playlist_id: latest_row && latest_row[:playlist_id],
+        queue_track_ids: latest_row && latest_row[:queue_track_ids],
+        past_track_ids: latest_row && latest_row[:past_track_ids]
+      }
+
+      if latest_row
+        Db.spotify_tokens.where(id: latest_row[:id]).update(payload.reject { |key, _| key == :user_id })
+        query.exclude(id: latest_row[:id]).delete
+      else
+        Db.spotify_tokens.insert(payload)
+      end
+    end
+
+    def persist_spotify_options!(options)
+      Db.spotify_tokens.where(user_id: user_id).update(options: JSON.pretty_generate(options))
+    end
+
+    def load_queue_state!
+      queued_ids = deserialize_track_ids(database_row[:queue_track_ids])
+      past_ids = deserialize_track_ids(database_row[:past_track_ids])
+
+      @queued_songs = queued_ids.map { |track_id| find_song(track_id) }.compact
+      @past_songs = past_ids.map { |track_id| find_song(track_id) }.compact
+
+      persist_queue_state! if queued_ids.length != @queued_songs.length || past_ids.length != @past_songs.length
+    end
+
+    def persist_queue_state!
+      return if database_row.nil?
+
+      Db.spotify_tokens.where(user_id: user_id).update(
+        queue_track_ids: JSON.generate(queued_song_ids),
+        past_track_ids: JSON.generate(past_song_ids)
       )
+    end
+
+    def queued_song_ids
+      queued_songs.filter_map { |track| track&.id.to_s if track&.id.to_s.length.positive? }
+    end
+
+    def past_song_ids
+      past_songs.filter_map { |track| track&.id.to_s if track&.id.to_s.length.positive? }
+    end
+
+    def deserialize_track_ids(raw_ids)
+      parsed_ids = JSON.parse(raw_ids.to_s)
+      return parsed_ids if parsed_ids.is_a?(Array)
+
+      []
+    rescue JSON::ParserError
+      []
+    end
+
+    def clear_party_playlist!
+      current_tracks = party_playlist.tracks
+      party_playlist.remove_tracks!(current_tracks) if current_tracks.any?
+    end
+
+    def cleanup_playlist_song!(song)
+      return if song.nil?
+
+      party_playlist.remove_tracks!([song])
+    rescue => ex
+      puts "Failed to clean up temporary Spotify queue song for user #{user_id}"
+      puts ex
     end
   end
 end

--- a/views/add_playlist_to_favs.erb
+++ b/views/add_playlist_to_favs.erb
@@ -1,4 +1,4 @@
-<h1>Aux cord</a></h1>
+<h1>Aux cord</h1>
 
 <% if @already_submitted %>
   <h2 style="color: rgb(175, 0, 0)">Could not find the playlist, please make sure to follow the steps below</h2>
@@ -10,7 +10,7 @@
 
 <ol>
   <li>Open the <b>Sonos app</b> on your iPhone or Android</li>
-  <li>Switch to <b>Search</b> and enter <b>"<%= @spotify_playlist_name %>"</b> for <b>Playlists</b></li>
+  <li>Switch to <b>Search</b> and enter <b>"<%= Rack::Utils.escape_html(@spotify_playlist_name.to_s) %>"</b> for <b>Playlists</b></li>
   <li>Select the playlist</li>
   <li>Tap on the top right 3 dots ...</li>
   <li>Tap on <b>Add Playlist to My Sonos</b></li>
@@ -27,7 +27,10 @@
 <img src="/assets/add-to-sonos-3.png" class="screenshot-framed" />
 
 <div id="footer">
-  <a href="/logout" onclick="return confirm('Are you sure you want to delete your Spotify & Sonos login tokens, and logout from auxcord.org? You will need to do the full onboarding flow again if you want to use auxcord.org again!')">Don't want to finish onboarding? Click here to logout & Remove all Login tokens</a>
+  <form action="/logout" method="post" onsubmit="return confirm('Are you sure you want to delete your Spotify & Sonos login tokens, and logout from auxcord.org? You will need to do the full onboarding flow again if you want to use auxcord.org again!')">
+    <input type="hidden" name="csrf_token" value="<%= Rack::Utils.escape_html(csrf_token) %>">
+    <button type="submit">Don't want to finish onboarding? Click here to logout & Remove all Login tokens</button>
+  </form>
 </div>
 
 <style type="text/css">

--- a/views/js/_login.js.erb
+++ b/views/js/_login.js.erb
@@ -1,6 +1,7 @@
 <script type="text/javascript">
   document.addEventListener("DOMContentLoaded", function(event) { 
-    carousel = document.getElementById('meme-carousel');
+    var carousel = document.getElementById('meme-carousel');
+    if (!carousel) { return; }
 
     // Randomize order of all images in the carousel
     for (var i = carousel.children.length; i >= 0; i--) {

--- a/views/js/_party.js.erb
+++ b/views/js/_party.js.erb
@@ -1,8 +1,10 @@
 <script type="text/javascript">
+  const csrfToken = "<%= Rack::Utils.escape_html(csrf_token) %>";
+
   function refreshUI(data) {
     if (data["nothing_playing"]) {
       document.getElementById("nothing-playing").style.display = "block";
-      document.getElementById("custom-group").innerHTML = '"' + data["group_to_use"] + '"';
+      document.getElementById("custom-group").textContent = '"' + data["group_to_use"] + '"';
       document.getElementById("everything-else").style.display = "none";
       return;
     } else {
@@ -12,11 +14,12 @@
 
     // document.getElementById("volume-label").innerHTML = data["volume"];
     document.getElementById("volume-slider").value = data["volume"];
-    document.getElementById("currently-playing-title").innerHTML = data["current_song_details"]["name"];
-    document.getElementById("currently-playing-cover").src = data["current_image_url"];
-    document.getElementById("playing-next-cover").src = data["next_image_url"];
-    document.getElementById(data["party_on"] ? 'svg-play' : 'svg-pause').style.display = "none";
-    document.getElementById("party-join-link").children[0].innerHTML = data["party_join_link"];
+    document.getElementById("currently-playing-title").textContent = data["current_song_details"]["name"];
+    document.getElementById("currently-playing-cover").src = data["current_image_url"] || "";
+    document.getElementById("playing-next-cover").src = data["next_image_url"] || "";
+    document.getElementById("svg-play").style.display = data["party_on"] ? "none" : "block";
+    document.getElementById("svg-pause").style.display = data["party_on"] ? "block" : "none";
+    document.getElementById("party-join-link").children[0].textContent = data["party_join_link"];
     document.getElementById("party-join-link").children[0].href = data["party_join_link"];
     // document.getElementById("spotify-link").href = data["spotify_url"];
     // document.getElementById("spotify-link-2").href = data["spotify_url"];
@@ -24,16 +27,16 @@
     partyOn = data["party_on"];
     
     // Render the current queue
-    const queueList = document.getElementById("queue-list")
-    queueList.innerHTML = "";
+    const queueList = document.getElementById("queue-list");
+    queueList.replaceChildren();
     for (const song of data["queued_songs"]) {
       const queueEntry = document.createElement("li");
       queueEntry.classList.add("queue-entry");
       const queueImage = document.createElement("img");
       queueImage.classList.add("queue-image");
-      queueImage.src = song["album_cover"]
+      queueImage.src = song["album_cover"] || "";
       const songName = document.createElement("span");
-      songName.innerHTML = song["name"] + " - " + song["artists"]
+      songName.textContent = song["name"] + " - " + song["artists"];
       queueEntry.appendChild(queueImage);
       queueEntry.appendChild(songName);
       queueList.appendChild(queueEntry);
@@ -41,29 +44,33 @@
     document.getElementById("no-songs-text").style.display = data["queued_songs"].length == 0 ? "block" : "none";
 
     // Render the available groups
-    // const groupDiv = document.getElementById("groups-div")
-    // groupDiv.innerHTML = "";
+    const groupDiv = document.getElementById("groups-div");
+    groupDiv.replaceChildren();
 
-    // for (const group of data["groups"]) {
-    //   const label = document.createElement("label");
-    //   label.classList.add("container");
-    //   label.innerHTML = group["name"] + " (" + group["number_of_speakers"] + " " + (group["number_of_speakers"] == 1 ? "speaker" : "speakers" + ")");
-    //   const input = document.createElement("input");
-    //   input.value = group["id"];
-    //   input.type = "radio";
-    //   input.name = "group";
-    //   input.onclick = function() {
-    //     updateGroup(group["id"]);
-    //   }
-    //   if (group["id"] == data["selected_group"]) {
-    //     input.checked = true;
-    //   }
-    //   const checkmark = document.createElement("span");
-    //   checkmark.classList.add("checkmark");
-    //   label.appendChild(input);
-    //   label.appendChild(checkmark);
-    //   groupDiv.appendChild(label);
-    // }
+    for (const group of data["groups"]) {
+      const label = document.createElement("label");
+      label.classList.add("container");
+
+      const input = document.createElement("input");
+      input.value = group["id"];
+      input.type = "radio";
+      input.name = "group";
+      input.onclick = function() {
+        updateGroup(group["id"]);
+      };
+      if (group["id"] == data["selected_group"]) {
+        input.checked = true;
+      }
+
+      const text = document.createTextNode(group["name"] + " (" + group["number_of_speakers"] + " " + (group["number_of_speakers"] == 1 ? "speaker" : "speakers") + ")");
+      const checkmark = document.createElement("span");
+      checkmark.classList.add("checkmark");
+
+      label.appendChild(text);
+      label.appendChild(input);
+      label.appendChild(checkmark);
+      groupDiv.appendChild(label);
+    }
   }
 
   //////////////////
@@ -73,8 +80,8 @@
   let partyOn = false;
   pausePlayButton.onclick = function() {
     partyOn = !partyOn;
-    document.getElementById(partyOn ? 'svg-pause' : 'svg-play').style.display = "block";
-    document.getElementById(partyOn ? 'svg-play' : 'svg-pause').style.display = "none";
+    document.getElementById("svg-play").style.display = partyOn ? "none" : "block";
+    document.getElementById("svg-pause").style.display = partyOn ? "block" : "none";
     sendUpdateRequest("party_toggle=" + partyOn);
   }
 
@@ -117,7 +124,7 @@
   let groupsVisible = false;
   groupsButton.onclick = function() {
     groupsVisible = !groupsVisible;
-    const groupsDiv = document.getElementById("groups-div")
+    const groupsDiv = document.getElementById("groups-div");
     groupsDiv.style.display = groupsVisible ? "block" : "none";
     if (groupsVisible) {
       groupsDiv.style.marginTop = (groupsDiv.scrollHeight * -1 - 50) + "px";
@@ -134,19 +141,20 @@
   //////////////////
   // API Requests
   //////////////////
-  refreshUI(<%= party_data.to_json %>)
+  refreshUI(<%= json_for_script(initial_party_data) %>);
   setInterval(triggerUIRefresh, 2500);
 
   function sendUpdateRequest(params) {
     var xhttp = new XMLHttpRequest();
     xhttp.open("POST", "/party/host/update", true);
     xhttp.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
-    xhttp.send(params);
+    xhttp.setRequestHeader("X-CSRF-Token", csrfToken);
+    xhttp.send(params + "&csrf_token=" + encodeURIComponent(csrfToken));
   }
 
   function triggerUIRefresh() {
     var xhr = new XMLHttpRequest();
-    xhr.open("GET", "/party.json", false);
+    xhr.open("GET", "/party.json", true);
     xhr.onload = function (e) {
       if (xhr.readyState === 4 && xhr.status === 200) {
         var data = JSON.parse(xhr.responseText);
@@ -155,7 +163,6 @@
         console.error(xhr.statusText);
       }
     };
-    xhr.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
     xhr.send();
   }
 </script>

--- a/views/js/_queue_song.js.erb
+++ b/views/js/_queue_song.js.erb
@@ -1,24 +1,48 @@
 <script type="text/javascript">
   function refreshAutocomplete() {
     console.log("Sending auto-complete request")
-    let ids = window.location.pathname.replace("/p/", "")
+    let ids = window.location.pathname.replace("/p/", "");
     var song = document.getElementById('song-input').value;
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', '/spotify/search/' + ids + '?song_name=' + song, true);
+    xhr.open('GET', '/spotify/search/' + ids + '?song_name=' + encodeURIComponent(song), true);
     xhr.onload = function() {
+      var songList = document.getElementById('song-list');
       if (xhr.status === 200) {
         var response = JSON.parse(xhr.responseText);
-        var html = '';
-        for (var i = 0; i < response.length; i++) {
-          html += '<li class="autocomplete-entry" onclick="queueSong(\'' + response[i].id + '\')">'
-          html += '<img src="' + response[i].thumbnail + '" class="autocomplete-image" />'
-          html += '<span class="autocomplete-label">' + response[i].name + '</span>'
-          html += '<span class="autocomplete-artist">' + response[i].artists.join(", ") + '</span>'
-          html += '</li>';
+        songList.replaceChildren();
+
+        if (!Array.isArray(response)) {
+          return;
         }
-        document.getElementById('song-list').innerHTML = html;
+
+        for (var i = 0; i < response.length; i++) {
+          var entry = document.createElement('li');
+          entry.className = 'autocomplete-entry';
+          entry.onclick = (function(songId) {
+            return function() {
+              queueSong(songId);
+            };
+          })(response[i].id);
+
+          var image = document.createElement('img');
+          image.src = response[i].thumbnail || '';
+          image.className = 'autocomplete-image';
+
+          var label = document.createElement('span');
+          label.className = 'autocomplete-label';
+          label.textContent = response[i].name;
+
+          var artist = document.createElement('span');
+          artist.className = 'autocomplete-artist';
+          artist.textContent = response[i].artists.join(", ");
+
+          entry.appendChild(image);
+          entry.appendChild(label);
+          entry.appendChild(artist);
+          songList.appendChild(entry);
+        }
       } else {
-        document.getElementById('song-list').innerHTML = ""
+        songList.replaceChildren();
       }
     };
     xhr.send();
@@ -43,13 +67,13 @@
           }
           alert(text);
           document.getElementById('song-input').value = '';
-          document.getElementById('song-list').innerHTML = ""
+          document.getElementById('song-list').replaceChildren();
           // reload page
           window.location.reload();
         } else if (response.error) {
           alert(response.error);
           document.getElementById('song-input').value = '';
-          document.getElementById('song-list').innerHTML = ""
+          document.getElementById('song-list').replaceChildren();
         } else {
           alert("Something went wrong queuing this song")
         }

--- a/views/login.erb
+++ b/views/login.erb
@@ -10,6 +10,8 @@
     <h1>
       <% if params["error"] == "no_sonos_system" %>
         Looks like your Sonos account isn't connected to a household.
+      <% elsif params["error"] == "invalid_sonos_state" %>
+        The Sonos login expired or did not match this browser session. Please try again.
       <% end %>
     </h1>
   </div>

--- a/views/party.erb
+++ b/views/party.erb
@@ -14,11 +14,11 @@
   </div>
 
   <div id="media-controls">
-    <button id="pause-play-button">
+    <button id="pause-play-button" type="button">
       <span id="svg-play"><%= erb :"svgs/_button-play.svg", layout: false %></span>
       <span id="svg-pause"><%= erb :"svgs/_button-pause.svg", layout: false %></span>
     </button>
-    <button id="next-song-button" onclick="skipSong()">
+    <button id="next-song-button" type="button" onclick="skipSong()">
       <%= erb :"svgs/_button-skip.svg", layout: false %>
     </button>
   </div>
@@ -39,22 +39,22 @@
   </div>
   <p id="party-join-link"><a target="_blank"></a></p>
   <div id="volume-container">
-    <button onclick="volumeDown()">
+    <button type="button" onclick="volumeDown()">
       <%= erb :"svgs/_button-arrow-left.svg", layout: false %>
     </button>
     <input type="range" min="0" max="100" value="" class="slider" id="volume-slider">
     <span id="volume-label"></span>
-    <button onclick="volumeUp()">
+    <button type="button" onclick="volumeUp()">
       <%= erb :"svgs/_button-arrow-right.svg", layout: false %>
     </button>
   </div>
   <hr />
     
-    <button id="groups-button">
-      <% # erb :"svgs/_button-groups.svg", layout: false %>
+    <button id="groups-button" type="button">
+      <%= erb :"svgs/_button-groups.svg", layout: false %>
     </button>
 
-  <%# <div id="groups-div"></div> %>
+  <div id="groups-div"></div>
 </div>
 
 <div id="instruction">
@@ -76,9 +76,12 @@
   </ul>
 </div>
 
-<%= erb :"js/_party.js", layout: false %>
+<%= erb :"js/_party.js", layout: false, locals: { initial_party_data: initial_party_data, csrf_token: csrf_token } %>
 <%= erb :"css/_party.css", layout: false %>
 
 <div id="footer">
-  <a href="/logout" onclick="return confirm('Are you sure you want to delete your Spotify & Sonos login tokens, and logout from auxcord.org? You will need to do the full onboarding flow again if you want to use auxcord.org again!')">Logout & Remove all Login tokens</a>
+  <form action="/logout" method="post" onsubmit="return confirm('Are you sure you want to delete your Spotify & Sonos login tokens, and logout from auxcord.org? You will need to do the full onboarding flow again if you want to use auxcord.org again!')">
+    <input type="hidden" name="csrf_token" value="<%= Rack::Utils.escape_html(csrf_token) %>">
+    <button type="submit">Logout & Remove all Login tokens</button>
+  </form>
 </div>

--- a/views/queue_song.erb
+++ b/views/queue_song.erb
@@ -8,8 +8,8 @@
     <ul id="queue-list">
       <% @queued_songs.each do |song| %>
         <li class="queue-entry">
-          <img class="queue-image" src="<%= song[:album_cover] %>" />
-          <span><%= song[:name] %> - <%= song[:artists] %></span>
+          <img class="queue-image" src="<%= Rack::Utils.escape_html(song[:album_cover].to_s) %>" />
+          <span><%= Rack::Utils.escape_html(song[:name].to_s) %> - <%= Rack::Utils.escape_html(song[:artists].to_s) %></span>
         </li>
       <% end %>
     </ul>
@@ -34,7 +34,7 @@
   <a href="https://auxcord.org" target="_blank">AuxCord.org</a>,
   a free service that lets your guests add their own songs.
 </p>
-<p>This project was built by <a href="https://krausefx.com/about" target="_blank">Felix Krause</p>
+<p>This project was built by <a href="https://krausefx.com/about" target="_blank">Felix Krause</a></p>
 
 <%= erb :"js/_queue_song.js", layout: false %>
 <%= erb :"css/_queue_song.css", layout: false %>


### PR DESCRIPTION
## Summary

Full code audit + fix for auxcord.org. Addresses all 28 bugs identified in `FINDINGS.md`.

### Critical fixes (songs not playing / queue breaking)
1. **Queue state persisted to DB** — survives restarts, deploys, crashes
2. **Mutex on queue mutations** — prevents race conditions between concurrent guest requests
3. **Sonos insert is synchronous with retry** — success only returned after insert actually succeeds
4. **`currently_playing_guest_wished_song` set only after success** — failed inserts no longer wedge the queue
5. **Sonos callback returns 200 immediately** — defers processing to background thread (Sonos 1s timeout)
6. **Sonos subscriptions auto-renew** every 24h + on group change

### High priority
- Background threads: per-user rescue/retry (no more permanent thread death)
- Logout clears in-memory GlobalState instances
- Nil guards on all guest routes (stale links return 404 instead of 500)
- Nil guard after `find_song` for bad/removed track IDs
- Random OAuth state for Sonos auth (was hardcoded `TESTSTATE`)
- CSRF tokens on all state-changing POST endpoints
- Spotify token refresh persisted via `access_refresh_callback`
- Upsert for Spotify auth rows (no more duplicate credential rows)
- `primary_household` rescue returns `.first['id']` not `.first` (hash)

### Medium
- Group validation with auto-fallback if selected group disappears
- Removed `audio_features` from search (slow, fragile, unnecessary)
- `encodeURIComponent` on search input
- Async XHR for host dashboard (was synchronous, froze UI)
- Groups div uncommented + JS reference fixed
- Play/pause icons: explicit show/hide both on every state change
- Login carousel JS: null guard
- `party_data` passed to template (no duplicate API calls)

### Security
- HTML-escape all third-party metadata in ERB (`Rack::Utils.escape_html`)
- `textContent` / DOM API instead of `innerHTML` in all JS (XSS fix)

### Minor
- Fixed asset whitelist extensions
- Fixed missing `</a>` tag

### Files changed
```
db.rb, server.rb, sonos.rb, spotify.rb
views/: party.erb, queue_song.erb, login.erb, add_playlist_to_favs.erb
views/js/: _party.js.erb, _queue_song.js.erb, _login.js.erb
```

All Ruby files pass `ruby -c` syntax check. No new gems added.