### PR TITLE
Handle malformed Sonos favorites during playlist lookup

### DIFF
--- a/sonos.rb
+++ b/sonos.rb
@@ -82,10 +82,19 @@ module SonosPartyMode
     def ensure_playlist_in_favorites(spotify_playlist_id, force_refresh: true)
       favs = favorites_cached unless force_refresh
       favs ||= client_control_request("/households/#{primary_household}/favorites")
-      return favs.fetch('items').find do |fav|
-        fav['service']['name'] == 'Spotify' &&
-        fav['resource']['type'] == 'PLAYLIST' &&
-        fav['resource']['id']['objectId'].include?(spotify_playlist_id)
+      items = favs.is_a?(Hash) ? Array(favs['items']) : []
+      return items.find do |fav|
+        next false unless fav.is_a?(Hash)
+
+        service = fav['service']
+        resource = fav['resource']
+        resource_id = resource['id'] if resource.is_a?(Hash)
+        next false unless service.is_a?(Hash) && resource_id.is_a?(Hash)
+        next false unless service['name'] == 'Spotify'
+        next false unless resource['type'] == 'PLAYLIST'
+
+        object_id = resource_id['objectId']
+        object_id.is_a?(String) && object_id.include?(spotify_playlist_id)
       end
     rescue => ex
       puts "fav playlist error"

--- a/test/sonos_boot_test.rb
+++ b/test/sonos_boot_test.rb
@@ -36,4 +36,29 @@ class SonosBootTest < Minitest::Test
     assert_empty sonos.households
     assert_nil sonos.primary_household
   end
+
+  def test_playlist_lookup_skips_malformed_favorites
+    matching_favorite = {
+      'service' => { 'name' => 'Spotify' },
+      'resource' => {
+        'type' => 'PLAYLIST',
+        'id' => { 'objectId' => 'spotify:playlist:target-playlist' }
+      }
+    }
+    favorites = {
+      'items' => [
+        { 'service' => nil, 'resource' => nil },
+        {
+          'service' => { 'name' => 'Spotify' },
+          'resource' => { 'type' => 'PLAYLIST', 'id' => nil }
+        },
+        matching_favorite
+      ]
+    }
+    sonos = SonosPartyMode::Sonos.allocate
+    sonos.define_singleton_method(:primary_household) { 'household-id' }
+    sonos.define_singleton_method(:client_control_request) { |_path| favorites }
+
+    assert_same matching_favorite, sonos.ensure_playlist_in_favorites('target-playlist')
+  end
 end


### PR DESCRIPTION
## Problem

Sonos can return favorite entries without the nested `service`, `resource`, or `resource.id` fields expected by auxcord. The first malformed entry raises `NoMethodError`, aborts the entire search, and makes onboarding incorrectly report that the Spotify playlist is missing.

Railway logs from the reported failure showed repeated `fav playlist error` / `undefined method `[]` for nil:NilClass` messages.

## Change

- Treat a missing or malformed favorites collection as empty.
- Skip malformed favorite entries individually instead of aborting the lookup.
- Continue matching valid Spotify playlist favorites by object ID.
- Add a regression test with malformed entries before a valid matching playlist.

## Verification

- Regression test confirmed to fail before the implementation and pass afterward.
- `3 runs, 7 assertions, 0 failures` in the Ruby 3.0.2 Docker image.
- `ruby -c sonos.rb` and `ruby -c test/sonos_boot_test.rb`: syntax OK.
- RuboCop still reports 11 pre-existing offenses in `sonos.rb`; none are on the changed matcher or regression test.