### PR TITLE
Fix Spotify token recovery for party dashboard

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -159,10 +159,14 @@ module SonosPartyMode
       else
         return erb :party, locals: pd
       end
+    rescue SonosPartyMode::Spotify::ReauthorizationRequired
+      reauthorize_spotify!
     end
 
     get '/party.json' do
       unless all_sessions?
+        return spotify_reauthorization_required_response! if sonos_instances[session[:user_id]] && spotify_instances[session[:user_id]].nil?
+
         redirect '/'
         return
       end
@@ -172,6 +176,8 @@ module SonosPartyMode
       return {}.to_json if pd[:redirect] || pd[:erb]
 
       return pd.to_json
+    rescue SonosPartyMode::Spotify::ReauthorizationRequired
+      spotify_reauthorization_required_response!
     end
 
     def party_data
@@ -255,6 +261,26 @@ module SonosPartyMode
         party_join_link: generate_invite_url(request, spotify_playlist_id),
         spotify_url: spotify_url
       }
+    end
+
+    def reauthorize_spotify!
+      spotify_instances.delete(session[:user_id])
+      redirect '/auth/spotify'
+    end
+
+    def spotify_reauthorization_required_response!
+      spotify_instances.delete(session[:user_id])
+      content_type :json
+      status 401
+      return { reauthorization_required: true }.to_json
+    end
+
+    def spotify_guest_unavailable!(json: false)
+      status 503
+      return 'This party is temporarily unavailable' unless json
+
+      content_type :json
+      return { error: 'spotify_reauthorization_required' }.to_json
     end
 
     def generate_invite_url(request, spotify_playlist_id)
@@ -357,6 +383,8 @@ module SonosPartyMode
 
       # No auth here, we just verify the 2 IDs
       spotify_instance = spotify_instances[params[:user_id].to_i]
+      return spotify_guest_unavailable! unless spotify_instance
+
       spotify_playlist = spotify_instance.party_playlist
       if spotify_playlist.id != params[:playlist_id]
         redirect '/'
@@ -368,6 +396,8 @@ module SonosPartyMode
       @queued_songs = queued_songs_json(spotify_instance, sonos_instance)
 
       erb :queue_song
+    rescue SonosPartyMode::Spotify::ReauthorizationRequired
+      spotify_guest_unavailable!
     end
 
     # User submitted a song request
@@ -376,6 +406,8 @@ module SonosPartyMode
 
       user_id = params[:user_id].to_i
       spotify_instance = spotify_instances[user_id]
+      return spotify_guest_unavailable!(json: true) unless spotify_instance
+
       spotify_playlist = spotify_instance.party_playlist
       sonos_instance = sonos_instances[user_id]
 
@@ -413,13 +445,20 @@ module SonosPartyMode
         end
         sonos_instance.currently_playing_guest_wished_song = true
         Thread.new do # async
-          spotify_instance.add_next_song_to_sonos_queue!(sonos_instance)
+          begin
+            spotify_instance.add_next_song_to_sonos_queue!(sonos_instance)
+          rescue SonosPartyMode::Spotify::ReauthorizationRequired
+            spotify_instances.delete(user_id)
+            puts "Spotify reauthorization required for user #{user_id}"
+          end
         end
         return {
           success: true,
           position: 0
         }.to_json
       end
+    rescue SonosPartyMode::Spotify::ReauthorizationRequired
+      spotify_guest_unavailable!(json: true)
     end
 
     # -----------------------
@@ -588,6 +627,13 @@ module SonosPartyMode
       # As a best practice, you should unsubscribe to namespaces before terminating your event service.
       status 200
       body ''
+    rescue SonosPartyMode::Spotify::ReauthorizationRequired
+      if spotify_instance
+        spotify_instances.delete(spotify_instance.user_id)
+        puts "Spotify reauthorization required for user #{spotify_instance.user_id}"
+      end
+      status 200
+      body ''
     end
 
     # -----------------------
@@ -598,6 +644,11 @@ module SonosPartyMode
     SPOTIFY_REDIRECT_URI = "#{HOST_URL}#{SPOTIFY_REDIRECT_PATH}".freeze
 
     get SPOTIFY_REDIRECT_PATH do
+      unless sonos_instances[session[:user_id]]
+        redirect '/'
+        return
+      end
+
       if params[:state] == Hash(session)['state_key']
         session[:state_key] = nil
 
@@ -614,6 +665,11 @@ module SonosPartyMode
     end
 
     get '/auth/spotify' do
+      unless sonos_instances[session[:user_id]]
+        redirect '/'
+        return
+      end
+
       session[:state_key] = SecureRandom.hex
 
       redirect('https://accounts.spotify.com/authorize?' +
@@ -631,14 +687,17 @@ module SonosPartyMode
 
       song_name = params.fetch(:song_name)
       user_id = params[:user_id].to_i
-      spotify_playlist = spotify_instances[user_id].party_playlist
+      spotify_instance = spotify_instances[user_id]
+      return spotify_guest_unavailable!(json: true) unless spotify_instance
+
+      spotify_playlist = spotify_instance.party_playlist
 
       # To make sure the user actually has the full link, and the IDs match
       return { error: 'Unauthorized' }.to_json if spotify_playlist.id != params[:playlist_id]
       return {}.to_json if song_name.to_s.strip.empty?
 
       puts "Searching for Spotify song using name #{song_name}"
-      songs = spotify_instances[user_id].search_for_song(song_name)
+      songs = spotify_instance.search_for_song(song_name)
       return songs.collect do |song|
         audio_features = song.audio_features
         {
@@ -656,6 +715,8 @@ module SonosPartyMode
           valence: audio_features.valence,
         }
       end.to_json
+    rescue SonosPartyMode::Spotify::ReauthorizationRequired
+      spotify_guest_unavailable!(json: true)
     end
 
     # Caching state

--- a/sonos.rb
+++ b/sonos.rb
@@ -304,7 +304,6 @@ module SonosPartyMode
       )
 
       response = JSON.parse(response.body)
-      puts "sonos api response: #{response}"
       raise response['error'] if response['error'].to_s.length.positive?
 
       access_token = response.fetch('access_token')

--- a/spotify.rb
+++ b/spotify.rb
@@ -3,11 +3,16 @@
 require 'excon'
 require 'rspotify'
 require 'json'
+require 'base64'
+require 'uri'
 # require "pry"
 require_relative './db'
 
 module SonosPartyMode
   class Spotify
+    class ReauthorizationRequired < StandardError; end
+    class TokenRefreshFailed < StandardError; end
+
     attr_accessor :user_id, :queued_songs, :past_songs
 
     def initialize(user_id:, authorization_code: nil, redirect_uri: nil)
@@ -36,31 +41,120 @@ module SonosPartyMode
     def party_playlist
       return @_playlist if @_playlist
 
+      return party_playlist_without_refresh
+    end
+
+    def party_playlist_without_refresh
       # Find or create the Party playlist
       playlist_id = database_row.fetch(:playlist_id)
       unless playlist_id
         puts "Creating new playlist for user id #{user_id}"
-        playlist = spotify_user.create_playlist!("#{user_id} auxcord.org - Don't Delete")
+        playlist = spotify_request { spotify_user.create_playlist!("#{user_id} auxcord.org - Don't Delete") }
         playlist_id = playlist.id
+        Db.spotify_tokens.where(user_id: user_id).update(playlist_id: playlist_id)
         prepare_welcome_playlist_song!(playlist)
         puts "Finished creating playlist with id #{playlist_id}"
 
         # Verify that the playlist was created and contains one song
-        raise 'Playlist was not created' if playlist.tracks.count == 0
-
-        # Remember the Spotify playlist ID
-        Db.spotify_tokens.where(user_id: user_id).update(playlist_id: playlist_id) # use full query syntax
+        raise 'Playlist was not created' if spotify_request { playlist.tracks.count } == 0
       end
-      return (@_playlist = RSpotify::Playlist.find(spotify_user.id, playlist_id))
+      return (@_playlist = spotify_request { RSpotify::Playlist.find(spotify_user.id, playlist_id) })
     end
+
+    def spotify_request(&request)
+      failed_access_token = spotify_credentials['token']
+      request.call
+    rescue RestClient::Unauthorized
+      refresh_and_retry_spotify_request(failed_access_token, &request)
+    end
+
+    def refresh_and_retry_spotify_request(failed_access_token, &request)
+      @refresh_mutex ||= Mutex.new
+      @refresh_mutex.synchronize do
+        # A concurrent request may already have refreshed and persisted the token.
+        if spotify_credentials['token'] == failed_access_token
+          refresh_spotify_credentials!
+        else
+          RSpotify::User.new(spotify_options)
+        end
+      end
+      return request.call
+    rescue RestClient::Unauthorized
+      raise ReauthorizationRequired, 'Spotify authorization is no longer valid'
+    end
+
+    def refresh_spotify_credentials!
+      options = spotify_options
+      credentials = options.fetch('credentials')
+      refresh_token = credentials['refresh_token']
+      raise ReauthorizationRequired, 'Spotify authorization is no longer valid' if refresh_token.to_s.empty?
+
+      auth_string = Base64.strict_encode64("#{ENV.fetch('SPOTIFY_CLIENT_ID')}:#{ENV.fetch('SPOTIFY_CLIENT_SECRET')}")
+      response = Excon.post(
+        'https://accounts.spotify.com/api/token',
+        body: URI.encode_www_form({
+                                    'grant_type' => 'refresh_token',
+                                    'refresh_token' => refresh_token
+                                  }),
+        headers: {
+          'Authorization' => "Basic #{auth_string}",
+          'Content-Type' => 'application/x-www-form-urlencoded'
+        }
+      )
+      unless response.status == 200
+        error_code = JSON.parse(response.body).fetch('error', nil)
+        raise ReauthorizationRequired, 'Spotify authorization is no longer valid' if response.status == 400 && error_code == 'invalid_grant'
+
+        raise TokenRefreshFailed, "Spotify token refresh failed with status #{response.status}"
+      end
+
+      refreshed = JSON.parse(response.body)
+      access_token = refreshed.fetch('access_token')
+      expires_in = refreshed.fetch('expires_in').to_i
+      credentials['token'] = access_token
+      credentials['access_token'] = access_token
+      credentials['expires_in'] = expires_in
+      credentials['expires_at'] = Time.now.to_i + expires_in
+      credentials['expires'] = true
+      credentials['refresh_token'] = refreshed['refresh_token'] unless refreshed['refresh_token'].to_s.empty?
+
+      Db.spotify_tokens.where(user_id: user_id).update(options: JSON.generate(options))
+      RSpotify::User.new(options) # Re-prime RSpotify's in-memory credentials before retrying.
+    rescue ReauthorizationRequired, TokenRefreshFailed
+      raise
+    rescue Excon::Error, JSON::ParserError, KeyError
+      raise TokenRefreshFailed, 'Spotify token refresh failed'
+    end
+
+    def spotify_options
+      JSON.parse(database_row.fetch(:options))
+    rescue JSON::ParserError, KeyError, NoMethodError, TypeError
+      raise ReauthorizationRequired, 'Spotify authorization is no longer valid'
+    end
+
+    def spotify_credentials
+      spotify_options.fetch('credentials')
+    rescue KeyError
+      raise ReauthorizationRequired, 'Spotify authorization is no longer valid'
+    end
+
+    def spotify_account_id(row)
+      JSON.parse(row.fetch(:options)).dig('info', 'id')
+    rescue JSON::ParserError, KeyError, TypeError
+      nil
+    end
+
+    private :party_playlist_without_refresh, :spotify_request, :refresh_and_retry_spotify_request,
+            :refresh_spotify_credentials!, :spotify_options, :spotify_credentials,
+            :spotify_account_id
 
     # Add a welcome song to the playlist, so Sonos can handle the playlist
     # Sonos app doesn't handle empty playlists well
     def prepare_welcome_playlist_song!(playlist)
-      return if playlist.tracks.count.positive?
+      return if spotify_request { playlist.tracks.count }.positive?
 
       hello_there_song = RSpotify::Track.search('Hello there dillon francis').first
-      playlist.add_tracks!([hello_there_song])
+      spotify_request { playlist.add_tracks!([hello_there_song]) }
     end
 
     def search_for_song(name)
@@ -91,7 +185,10 @@ module SonosPartyMode
     # Actually send all songs wished for to the Sonos queue
     def add_next_song_to_sonos_queue!(sonos)
       # First, clear the Spotify playlist, in case there was anything left there
-      party_playlist.remove_tracks!(party_playlist.tracks)
+      spotify_request do
+        playlist = party_playlist
+        playlist.remove_tracks!(playlist.tracks)
+      end
 
       next_song = queued_songs.shift
       if next_song.nil?
@@ -99,7 +196,7 @@ module SonosPartyMode
         return false
       end
       past_songs << next_song
-      party_playlist.add_tracks!([next_song])
+      spotify_request { party_playlist.add_tracks!([next_song]) }
 
       # Get the Sonos ID of the favorite playlist
       fav_id = sonos.ensure_playlist_in_favorites(party_playlist.id)
@@ -114,7 +211,7 @@ module SonosPartyMode
           action: 'INSERT_NEXT'
         }
       )
-      party_playlist.remove_tracks!([next_song])
+      spotify_request { party_playlist.remove_tracks!([next_song]) }
       return true
     end
 
@@ -156,10 +253,14 @@ module SonosPartyMode
         'info' => info_parsed
       }
       RSpotify::User.new(options)
-      Db.spotify_tokens.insert(
-        user_id: user_id,
-        options: JSON.pretty_generate(options.to_hash)
-      )
+      tokens = Db.spotify_tokens.where(user_id: user_id)
+      if tokens.empty?
+        tokens.insert(user_id: user_id, options: JSON.pretty_generate(options.to_hash))
+      else
+        matching_rows = tokens.all.select { |row| spotify_account_id(row) == info_parsed.fetch('id') }
+        playlist_id = matching_rows.filter_map { |row| row[:playlist_id] }.first
+        tokens.update(options: JSON.pretty_generate(options.to_hash), playlist_id: playlist_id)
+      end
     end
   end
 end

--- a/test/spotify_auth_test.rb
+++ b/test/spotify_auth_test.rb
@@ -1,0 +1,554 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'minitest/autorun'
+require 'rack/mock'
+require 'sinatra/base'
+require_relative '../spotify'
+
+class SpotifyAuthTest < Minitest::Test
+  class MemoryDataset
+    attr_reader :rows
+
+    def initialize(rows)
+      @rows = rows
+    end
+
+    def where(_conditions)
+      self
+    end
+
+    def empty?
+      rows.empty?
+    end
+
+    def first
+      rows.first
+    end
+
+    def all
+      rows
+    end
+
+    def update(attributes)
+      rows.each { |row| row.merge!(attributes) }
+      rows.length
+    end
+
+    def insert(attributes)
+      rows << attributes
+      attributes
+    end
+  end
+
+  Response = Struct.new(:status, :body)
+  Playlist = Struct.new(:id)
+
+  class PlaylistMutationDouble
+    attr_reader :add_calls, :remove_calls
+
+    def initialize(fail_on:, always_fail: false)
+      @fail_on = fail_on
+      @always_fail = always_fail
+      @add_calls = 0
+      @remove_calls = 0
+    end
+
+    def id
+      'party-playlist-id'
+    end
+
+    def tracks
+      []
+    end
+
+    def add_tracks!(_tracks)
+      @add_calls += 1
+      fail_if_needed!(:add, @add_calls)
+    end
+
+    def remove_tracks!(_tracks)
+      @remove_calls += 1
+      fail_if_needed!(:remove, @remove_calls)
+    end
+
+    private
+
+    def fail_if_needed!(operation, calls)
+      return unless operation == @fail_on
+      return unless @always_fail || calls == 1
+
+      raise RestClient::Unauthorized
+    end
+  end
+
+  Artist = Struct.new(:name)
+  Song = Struct.new(:name, :artists)
+
+  class SonosDouble
+    attr_reader :control_requests
+
+    def initialize
+      @control_requests = []
+    end
+
+    def ensure_playlist_in_favorites(_playlist_id)
+      { 'id' => 'favorite-id' }
+    end
+
+    def group_to_use
+      'group-id'
+    end
+
+    def client_control_request(path, options)
+      control_requests << [path, options]
+    end
+  end
+
+  def setup
+    @original_spotify_client_id = ENV.fetch('SPOTIFY_CLIENT_ID', nil)
+    @original_spotify_client_secret = ENV.fetch('SPOTIFY_CLIENT_SECRET', nil)
+    @original_custom_host_url = ENV.fetch('CUSTOM_HOST_URL', nil)
+    @original_session_secret = ENV.fetch('SESSION_SECRET', nil)
+    ENV['SPOTIFY_CLIENT_ID'] = 'test-client-id'
+    ENV['SPOTIFY_CLIENT_SECRET'] = 'test-client-secret'
+    ENV['CUSTOM_HOST_URL'] = 'https://example.test'
+    ENV['SESSION_SECRET'] = 'test-session-secret'
+    if defined?(GlobalState)
+      GlobalState[:spotify_instances].clear
+      GlobalState[:sonos_instances].clear
+    end
+
+    @stored_options = {
+      'credentials' => {
+        'token' => 'expired-access-token',
+        'access_token' => 'expired-access-token',
+        'refresh_token' => 'stored-refresh-token',
+        'expires_at' => 0
+      },
+      'info' => { 'id' => 'spotify-user-id' }
+    }
+    @dataset = MemoryDataset.new(
+      [
+        {
+          id: 1,
+          user_id: 7,
+          options: JSON.generate(@stored_options),
+          playlist_id: 'party-playlist-id'
+        }
+      ]
+    )
+  end
+
+  def test_unauthorized_playlist_lookup_refreshes_persists_and_retries_once
+    lookup_count = 0
+    playlist = Playlist.new('party-playlist-id')
+    playlist_lookup = lambda do |_owner_id, _playlist_id|
+      lookup_count += 1
+      raise RestClient::Unauthorized if lookup_count == 1
+
+      playlist
+    end
+    refresh_response = Response.new(200, JSON.generate(
+                                           access_token: 'fresh-access-token',
+                                           refresh_token: 'rotated-refresh-token',
+                                           expires_in: 3600
+                                         ))
+
+    result = with_spotify_stubs(playlist_lookup: playlist_lookup, token_response: refresh_response) do
+      SonosPartyMode::Spotify.new(user_id: 7).party_playlist
+    end
+
+    assert_same playlist, result
+    assert_equal 2, lookup_count
+
+    credentials = JSON.parse(@dataset.first.fetch(:options)).fetch('credentials')
+    assert_equal 'fresh-access-token', credentials.fetch('token')
+    assert_equal 'fresh-access-token', credentials.fetch('access_token')
+    assert_equal 'rotated-refresh-token', credentials.fetch('refresh_token')
+    assert_equal 3600, credentials.fetch('expires_in')
+    assert_equal true, credentials.fetch('expires')
+    assert_operator credentials.fetch('expires_at'), :>, Time.now.to_i
+    registered_credentials = RSpotify::User.class_variable_get(:@@users_credentials).fetch('spotify-user-id')
+    assert_equal 'fresh-access-token', registered_credentials.fetch('token')
+  end
+
+  def test_failed_refresh_requires_reauthorization_without_retrying
+    lookup_count = 0
+    playlist_lookup = lambda do |_owner_id, _playlist_id|
+      lookup_count += 1
+      raise RestClient::Unauthorized
+    end
+    refresh_response = Response.new(400, JSON.generate(error: 'invalid_grant'))
+
+    error = assert_raises(SonosPartyMode::Spotify::ReauthorizationRequired) do
+      with_spotify_stubs(playlist_lookup: playlist_lookup, token_response: refresh_response) do
+        SonosPartyMode::Spotify.new(user_id: 7).party_playlist
+      end
+    end
+
+    assert_equal 1, lookup_count
+    assert_match(/Spotify authorization/i, error.message)
+  end
+
+  def test_invalid_client_refresh_failure_remains_an_operational_error
+    playlist_lookup = ->(*) { raise RestClient::Unauthorized }
+    refresh_response = Response.new(400, JSON.generate(error: 'invalid_client'))
+
+    assert_raises(SonosPartyMode::Spotify::TokenRefreshFailed) do
+      with_spotify_stubs(playlist_lookup: playlist_lookup, token_response: refresh_response) do
+        SonosPartyMode::Spotify.new(user_id: 7).party_playlist
+      end
+    end
+  end
+
+  def test_spotify_server_failure_remains_an_operational_error
+    playlist_lookup = ->(*) { raise RestClient::Unauthorized }
+    refresh_response = Response.new(500, JSON.generate(error: 'invalid_grant'))
+
+    assert_raises(SonosPartyMode::Spotify::TokenRefreshFailed) do
+      with_spotify_stubs(playlist_lookup: playlist_lookup, token_response: refresh_response) do
+        SonosPartyMode::Spotify.new(user_id: 7).party_playlist
+      end
+    end
+  end
+
+  def test_second_unauthorized_response_requires_reauthorization_without_looping
+    lookup_count = 0
+    playlist_lookup = lambda do |_owner_id, _playlist_id|
+      lookup_count += 1
+      raise RestClient::Unauthorized
+    end
+    refresh_response = Response.new(200, JSON.generate(
+                                           access_token: 'fresh-access-token',
+                                           expires_in: 3600
+                                         ))
+
+    assert_raises(SonosPartyMode::Spotify::ReauthorizationRequired) do
+      with_spotify_stubs(playlist_lookup: playlist_lookup, token_response: refresh_response) do
+        SonosPartyMode::Spotify.new(user_id: 7).party_playlist
+      end
+    end
+
+    assert_equal 2, lookup_count
+    credentials = JSON.parse(@dataset.first.fetch(:options)).fetch('credentials')
+    assert_equal 'stored-refresh-token', credentials.fetch('refresh_token')
+  end
+
+  def test_cached_playlist_remove_refreshes_and_retries_once
+    playlist = PlaylistMutationDouble.new(fail_on: :remove)
+
+    result = exercise_queue_mutation(playlist)
+
+    assert_equal true, result
+    assert_equal 3, playlist.remove_calls
+    assert_equal 1, playlist.add_calls
+    assert_equal 'fresh-access-token', stored_credentials.fetch('token')
+  end
+
+  def test_cached_playlist_add_refreshes_and_retries_once
+    playlist = PlaylistMutationDouble.new(fail_on: :add)
+
+    result = exercise_queue_mutation(playlist)
+
+    assert_equal true, result
+    assert_equal 2, playlist.add_calls
+    assert_equal 2, playlist.remove_calls
+    assert_equal 'fresh-access-token', stored_credentials.fetch('token')
+  end
+
+  def test_second_unauthorized_playlist_mutation_requires_reauthorization
+    playlist = PlaylistMutationDouble.new(fail_on: :remove, always_fail: true)
+
+    assert_raises(SonosPartyMode::Spotify::ReauthorizationRequired) do
+      exercise_queue_mutation(playlist)
+    end
+
+    assert_equal 2, playlist.remove_calls
+  end
+
+  def test_mutation_retry_reuses_cached_playlist_without_recursive_locking
+    playlist = PlaylistMutationDouble.new(fail_on: :remove)
+    playlist_lookup = ->(*) { raise RestClient::Unauthorized }
+
+    result = exercise_queue_mutation(playlist, playlist_lookup: playlist_lookup)
+
+    assert_equal true, result
+    assert_equal 3, playlist.remove_calls
+  end
+
+  def test_new_authorization_updates_existing_row_and_preserves_playlist
+    authorize_spotify(profile_id: 'spotify-user-id')
+
+    assert_equal 1, @dataset.rows.length
+    assert_equal 'party-playlist-id', @dataset.first.fetch(:playlist_id)
+    credentials = JSON.parse(@dataset.first.fetch(:options)).fetch('credentials')
+    assert_equal 'fresh-access-token', credentials.fetch('token')
+    assert_equal 'fresh-refresh-token', credentials.fetch('refresh_token')
+  end
+
+  def test_new_authorization_for_a_different_spotify_account_clears_playlist
+    authorize_spotify(profile_id: 'different-spotify-user-id')
+
+    assert_nil @dataset.first.fetch(:playlist_id)
+  end
+
+  def test_new_authorization_inserts_a_new_token_row
+    @dataset = MemoryDataset.new([])
+    authorize_spotify(profile_id: 'spotify-user-id')
+
+    assert_equal 1, @dataset.rows.length
+    assert_equal 7, @dataset.first.fetch(:user_id)
+    assert_equal 'spotify-user-id', JSON.parse(@dataset.first.fetch(:options)).dig('info', 'id')
+  end
+
+  def test_new_authorization_reconciles_existing_duplicate_rows
+    @dataset.rows << {
+      id: 2,
+      user_id: 7,
+      options: JSON.generate(@stored_options),
+      playlist_id: nil
+    }
+    authorize_spotify(profile_id: 'spotify-user-id')
+
+    assert_equal ['party-playlist-id'], @dataset.rows.map { |row| row[:playlist_id] }.uniq
+    assert_equal 1, @dataset.rows.map { |row| row[:options] }.uniq.length
+  end
+
+  def test_malformed_legacy_credentials_require_reauthorization
+    @dataset.first[:options] = nil
+
+    assert_raises(SonosPartyMode::Spotify::ReauthorizationRequired) do
+      SonosPartyMode::Db.stub(:spotify_tokens, @dataset) do
+        SonosPartyMode::Spotify.new(user_id: 7).party_playlist
+      end
+    end
+  end
+
+  def test_sonos_authorization_does_not_log_oauth_credentials
+    sonos_source = File.read(File.expand_path('../sonos.rb', __dir__))
+
+    refute_includes sonos_source, 'sonos api response:'
+  end
+
+  def test_spotify_reauthorization_redirects_to_oauth_flow
+    load_server_without_running
+    GlobalState[:spotify_instances][7] = :stale
+    response = Rack::MockRequest.new(spotify_reauthorization_test_app.new).get('/party')
+
+    assert_equal 302, response.status
+    assert_equal 'http://example.org/auth/spotify', response.location
+    refute GlobalState[:spotify_instances].key?(7)
+  end
+
+  def test_party_json_signals_reauthorization_without_redirecting_to_spotify
+    load_server_without_running
+    GlobalState[:spotify_instances][7] = :stale
+    response = Rack::MockRequest.new(spotify_reauthorization_test_app.new).get('/party.json')
+
+    assert_equal 401, response.status
+    assert_nil response.location
+    assert_equal({ 'reauthorization_required' => true }, JSON.parse(response.body))
+    refute GlobalState[:spotify_instances].key?(7)
+  end
+
+  def test_party_json_signals_reauthorization_after_callback_invalidates_spotify
+    load_server_without_running
+    GlobalState[:sonos_instances][7] = Object.new
+    response = Rack::MockRequest.new(authenticated_route_test_app.new).get('/party.json')
+
+    assert_equal 401, response.status
+    assert_nil response.location
+    assert_equal({ 'reauthorization_required' => true }, JSON.parse(response.body))
+  end
+
+  def test_party_polling_redirects_the_host_when_reauthorization_is_required
+    party_javascript = File.read(File.expand_path('../views/js/_party.js.erb', __dir__))
+
+    assert_includes party_javascript, 'xhr.status === 401'
+    assert_includes party_javascript, 'window.location.href = "/auth/spotify";'
+  end
+
+  def test_guest_party_page_does_not_redirect_into_owner_oauth
+    load_server_without_running
+    GlobalState[:spotify_instances][7] = reauthorization_required_spotify
+    response = Rack::MockRequest.new(route_test_app.new).get('/p/7/party-playlist-id')
+
+    assert_equal 503, response.status
+    assert_nil response.location
+  end
+
+  def test_guest_search_does_not_redirect_into_owner_oauth
+    load_server_without_running
+    GlobalState[:spotify_instances][7] = reauthorization_required_spotify
+    response = Rack::MockRequest.new(route_test_app.new)
+                                .get('/spotify/search/7/party-playlist-id?song_name=test')
+
+    assert_equal 503, response.status
+    assert_nil response.location
+    assert_equal 'spotify_reauthorization_required', JSON.parse(response.body).fetch('error')
+  end
+
+  def test_guest_song_submission_does_not_redirect_into_owner_oauth
+    load_server_without_running
+    GlobalState[:spotify_instances][7] = reauthorization_required_spotify
+    response = Rack::MockRequest.new(route_test_app.new).post('/p/7/party-playlist-id/song-id')
+
+    assert_equal 503, response.status
+    assert_nil response.location
+    assert_equal 'spotify_reauthorization_required', JSON.parse(response.body).fetch('error')
+  end
+
+  def test_guest_routes_are_unavailable_after_owner_spotify_instance_is_invalidated
+    load_server_without_running
+    request = Rack::MockRequest.new(route_test_app.new)
+
+    party_response = request.get('/p/7/party-playlist-id')
+    search_response = request.get('/spotify/search/7/party-playlist-id?song_name=test')
+    submission_response = request.post('/p/7/party-playlist-id/song-id')
+
+    assert_equal [503, 503, 503], [party_response.status, search_response.status, submission_response.status]
+    assert_nil party_response.location
+    assert_nil search_response.location
+    assert_nil submission_response.location
+  end
+
+  def test_guest_cannot_start_spotify_oauth_without_a_sonos_session
+    load_server_without_running
+    response = Rack::MockRequest.new(route_test_app.new).get('/auth/spotify')
+
+    assert_equal 302, response.status
+    assert_equal 'http://example.org/', response.location
+  end
+
+  def test_sonos_callback_acknowledges_revoked_spotify_authorization
+    load_server_without_running
+    spotify = Object.new
+    spotify.define_singleton_method(:user_id) { 7 }
+    spotify.define_singleton_method(:add_next_song_to_sonos_queue!) do |_sonos|
+      raise SonosPartyMode::Spotify::ReauthorizationRequired
+    end
+    sonos = Struct.new(:group_to_use, :user_id, :current_item_id).new('group-id', 7, 'previous-item')
+    GlobalState[:spotify_instances][7] = spotify
+    GlobalState[:sonos_instances][7] = sonos
+
+    response = Rack::MockRequest.new(route_test_app.new).post(
+      '/callback',
+      'HTTP_X_SONOS_TARGET_VALUE' => 'group-id',
+      input: JSON.generate(itemId: 'new-item', previousItemId: 'previous-item')
+    )
+
+    assert_equal 200, response.status
+    refute GlobalState[:spotify_instances].key?(7)
+  end
+
+  def teardown
+    ENV['SPOTIFY_CLIENT_ID'] = @original_spotify_client_id
+    ENV['SPOTIFY_CLIENT_SECRET'] = @original_spotify_client_secret
+    ENV['CUSTOM_HOST_URL'] = @original_custom_host_url
+    ENV['SESSION_SECRET'] = @original_session_secret
+  end
+
+  private
+
+  def with_spotify_stubs(playlist_lookup:, token_response:, &block)
+    SonosPartyMode::Db.stub(:spotify_tokens, @dataset) do
+      RSpotify::Playlist.stub(:find, playlist_lookup) do
+        with_singleton_method(Excon, :post, ->(*) { token_response }) do
+          block.call
+        end
+      end
+    end
+  end
+
+  def exercise_queue_mutation(playlist, playlist_lookup: ->(*) { playlist })
+    token_response = Response.new(200, JSON.generate(
+                                         access_token: 'fresh-access-token',
+                                         expires_in: 3600
+                                       ))
+    with_spotify_stubs(playlist_lookup: playlist_lookup, token_response: token_response) do
+      spotify = SonosPartyMode::Spotify.new(user_id: 7)
+      spotify.instance_variable_set(:@_playlist, playlist)
+      spotify.queued_songs << Song.new('Test song', [Artist.new('Test artist')])
+      spotify.add_next_song_to_sonos_queue!(SonosDouble.new)
+    end
+  end
+
+  def stored_credentials
+    JSON.parse(@dataset.first.fetch(:options)).fetch('credentials')
+  end
+
+  def authorize_spotify(profile_id:)
+    token_response = Response.new(200, JSON.generate(
+                                         access_token: 'fresh-access-token',
+                                         refresh_token: 'fresh-refresh-token',
+                                         expires_in: 3600
+                                       ))
+    profile_response = Response.new(200, JSON.generate(id: profile_id))
+    SonosPartyMode::Db.stub(:spotify_tokens, @dataset) do
+      with_singleton_method(Excon, :post, ->(*) { token_response }) do
+        with_singleton_method(Excon, :get, ->(*) { profile_response }) do
+          SonosPartyMode::Spotify.new(
+            user_id: 7,
+            authorization_code: 'authorization-code',
+            redirect_uri: 'https://example.test/auth/spotify/callback'
+          )
+        end
+      end
+    end
+  end
+
+  def with_singleton_method(object, method_name, replacement, &block)
+    singleton_class = object.singleton_class
+    original_method = object.method(method_name)
+    singleton_class.define_method(method_name, replacement)
+    block.call
+  ensure
+    singleton_class.define_method(method_name, original_method)
+  end
+
+  def load_server_without_running
+    return if defined?(SonosPartyMode::Server)
+
+    original_run = Sinatra::Base.method(:run!)
+    Sinatra::Base.singleton_class.define_method(:run!) { |*| nil }
+    require_relative '../server'
+  ensure
+    Sinatra::Base.singleton_class.define_method(:run!, original_run) if original_run
+  end
+
+  def spotify_reauthorization_test_app
+    Class.new(SonosPartyMode::Server) do
+      define_method(:initialize) do |app = nil|
+        Sinatra::Base.instance_method(:initialize).bind(self).call(app)
+      end
+      define_method(:all_sessions?) { true }
+      define_method(:party_data) do
+        session[:user_id] = 7
+        raise SonosPartyMode::Spotify::ReauthorizationRequired
+      end
+    end
+  end
+
+  def route_test_app
+    Class.new(SonosPartyMode::Server) do
+      define_method(:initialize) do |app = nil|
+        Sinatra::Base.instance_method(:initialize).bind(self).call(app)
+      end
+    end
+  end
+
+  def authenticated_route_test_app
+    Class.new(route_test_app) do
+      before { session[:user_id] = 7 }
+    end
+  end
+
+  def reauthorization_required_spotify
+    Object.new.tap do |spotify|
+      spotify.define_singleton_method(:party_playlist) do
+        raise SonosPartyMode::Spotify::ReauthorizationRequired
+      end
+    end
+  end
+end

--- a/views/js/_party.js.erb
+++ b/views/js/_party.js.erb
@@ -148,7 +148,9 @@
     var xhr = new XMLHttpRequest();
     xhr.open("GET", "/party.json", false);
     xhr.onload = function (e) {
-      if (xhr.readyState === 4 && xhr.status === 200) {
+      if (xhr.readyState === 4 && xhr.status === 401) {
+        window.location.href = "/auth/spotify";
+      } else if (xhr.readyState === 4 && xhr.status === 200) {
         var data = JSON.parse(xhr.responseText);
         refreshUI(data);
       } else {


### PR DESCRIPTION
## Summary

Fixes the confirmed production failure where `GET /party` returned HTTP 500 after Spotify rejected the stored user access token.

- Refreshes Spotify credentials once after an unauthorized playlist lookup or authenticated playlist mutation, persists the complete credential state, re-primes RSpotify, and retries the failed request exactly once.
- Treats `invalid_grant` as a reauthorization requirement while leaving client-configuration and transient Spotify failures as operational errors.
- Redirects only the authenticated host dashboard into Spotify OAuth; guest routes return 503, `/party.json` returns 401, and the host UI navigates to reauthorization.
- Requires an existing Sonos session before Spotify OAuth can start or complete, preventing orphan guest credentials.
- Updates/reconciles existing Spotify token rows instead of inserting another stale row, preserving the playlist only when the Spotify account is unchanged.
- Removes logging of the complete Sonos OAuth response, which included access and refresh tokens.

## Root cause

Railway logs for the incident showed:

```
RestClient::Unauthorized — 401 Unauthorized
rspotify/playlist.rb:57 in find
spotify.rb:54 in party_playlist
server.rb:181 in party_data
server.rb:153 in GET /party
```

RSpotify's built-in refresh path did not recover this response, and the exception reached Sinatra as HTTP 500.

## Test plan

- `ruby test/spotify_auth_test.rb` in the locked Ruby 3.0.2 container: 25 tests, 73 assertions, 0 failures.
- Full test suite in the locked Ruby 3.0.2 container: 28 tests, 80 assertions, 0 failures.
- Ruby syntax checks for `spotify.rb`, `server.rb`, `sonos.rb`, and the new test file.
- RuboCop for `test/spotify_auth_test.rb`: no offenses.
- Added-line security scan: no findings.
